### PR TITLE
Binary serialize

### DIFF
--- a/examples/Files/Basic/Data.cpp
+++ b/examples/Files/Basic/Data.cpp
@@ -40,7 +40,7 @@ std::ostream& operator<<(std::ostream& os, const Data& data) {
 }
 
 void Data::saveToBin(const std::string& file) const {
-    bl::BinaryFile output(file, bl::BinaryFile::Write);
+    bl::bf::BinaryFile output(file, bl::bf::BinaryFile::Write);
 
     output.write(name);
     output.write<uint32_t>(points.size());
@@ -48,7 +48,7 @@ void Data::saveToBin(const std::string& file) const {
 }
 
 bool Data::loadFromBin(const std::string& file) {
-    bl::BinaryFile input(file, bl::BinaryFile::Read);
+    bl::bf::BinaryFile input(file, bl::bf::BinaryFile::Read);
     if (!input.good()) return false;
 
     if (!input.read(name)) return false;

--- a/include/BLIB/Files/Binary.hpp
+++ b/include/BLIB/Files/Binary.hpp
@@ -1,6 +1,16 @@
 #ifndef BLIB_FILES_BINARY_HPP
 #define BLIB_FILES_BINARY_HPP
 
+/**
+ * @defgroup BinaryFiles
+ * @brief Collection of classes for encoding and decoding data into endian agnostic binary files.
+ *        Core class is BinaryFile
+ *
+ */
+
 #include <BLIB/Files/Binary/BinaryFile.hpp>
+#include <BLIB/Files/Binary/SerializableField.hpp>
+#include <BLIB/Files/Binary/SerializableObject.hpp>
+#include <BLIB/Files/Binary/Serializer.hpp>
 
 #endif

--- a/include/BLIB/Files/Binary/BinaryFile.hpp
+++ b/include/BLIB/Files/Binary/BinaryFile.hpp
@@ -152,7 +152,7 @@ template<typename T>
 typename std::enable_if<std::is_integral_v<T>, bool>::type BinaryFile::peek(T& output) {
     const std::size_t s = sizeof(T);
     const bool r        = read<T>(output);
-    handle.seekg(handle.tellg() - s);
+    handle.seekg(handle.tellg() - std::streamoff(s));
     return r;
 }
 

--- a/include/BLIB/Files/Binary/BinaryFile.hpp
+++ b/include/BLIB/Files/Binary/BinaryFile.hpp
@@ -70,6 +70,16 @@ public:
     typename std::enable_if<std::is_integral_v<T>, bool>::type read(T& output);
 
     /**
+     * @brief Peeks the integral type from the file without moving the cursor
+     *
+     * @tparam T The type to read. Be explicit with bit width and sign
+     * @param output Variable to write the read value to
+     * @return bool True if the value could be read
+     */
+    template<typename T>
+    typename std::enable_if<std::is_integral_v<T>, bool>::type peek(T& output);
+
+    /**
      * @brief Reads a string from the file
      *
      * @param output Variable to write the read string to
@@ -105,7 +115,7 @@ template<typename T>
 typename std::enable_if<std::is_integral_v<T>, bool>::type BinaryFile::write(const T& data) {
     if (!handle.good() || mode != Write) return false;
 
-    const size_t size = sizeof(T);
+    const std::size_t size = sizeof(T);
     char bytes[size];
     std::memcpy(bytes, &data, size);
     if (FileUtil::isBigEndian()) {
@@ -126,7 +136,7 @@ template<typename T>
 typename std::enable_if<std::is_integral_v<T>, bool>::type BinaryFile::read(T& output) {
     if (!handle.good() || mode != Read) return false;
 
-    const size_t size = sizeof(output);
+    const std::size_t size = sizeof(output);
     char bytes[size];
 
     output = 0;
@@ -136,6 +146,14 @@ typename std::enable_if<std::is_integral_v<T>, bool>::type BinaryFile::read(T& o
     }
     std::memcpy(&output, bytes, size);
     return handle.good();
+}
+
+template<typename T>
+typename std::enable_if<std::is_integral_v<T>, bool>::type BinaryFile::peek(T& output) {
+    const std::size_t s = sizeof(T);
+    const bool r        = read<T>(output);
+    handle.seekg(handle.tellg() - s);
+    return r;
 }
 
 inline bool BinaryFile::read(std::string& output) {

--- a/include/BLIB/Files/Binary/BinaryFile.hpp
+++ b/include/BLIB/Files/Binary/BinaryFile.hpp
@@ -10,13 +10,15 @@
 
 namespace bl
 {
+namespace bf
+{
 /**
  * @brief Utility class to read and write binary data. Endianness agnostic
  *        Floating point types are not supported. To store floating point
  *        values, simply store an integral type and multiply/divide on
  *        save/load
  *
- * @ingroup Files
+ * @ingroup BinaryFiles
  */
 class BinaryFile : private NonCopyable {
 public:
@@ -151,6 +153,7 @@ inline bool BinaryFile::good() {
     return handle.good() && !eof;
 }
 
+} // namespace bf
 } // namespace bl
 
 #endif

--- a/include/BLIB/Files/Binary/SerializableField.hpp
+++ b/include/BLIB/Files/Binary/SerializableField.hpp
@@ -35,6 +35,8 @@ public:
 
     SerializableField& operator=(const T& v);
 
+    operator T() const;
+
     SerializableField(const SerializableField&) = delete;
 
 private:
@@ -71,6 +73,11 @@ template<typename T>
 SerializableField<T>& SerializableField<T>::operator=(const T& v) {
     value = v;
     return *this;
+}
+
+template<typename T>
+SerializableField<T>::operator T() const {
+    return value;
 }
 
 } // namespace bf

--- a/include/BLIB/Files/Binary/SerializableField.hpp
+++ b/include/BLIB/Files/Binary/SerializableField.hpp
@@ -1,0 +1,79 @@
+#ifndef BLIB_FILES_BINARY_SERIALIZABLEFIELD_HPP
+#define BLIB_FILES_BINARY_SERIALIZABLEFIELD_HPP
+
+#include <BLIB/Files/Binary/BinaryFile.hpp>
+#include <BLIB/Files/Binary/Serializer.hpp>
+
+namespace bl
+{
+namespace bf
+{
+class SerializableObject;
+
+class SerializableFieldBase {
+public:
+    virtual bool serialize(BinaryFile& output) const = 0;
+
+    virtual bool deserialize(BinaryFile& input) = 0;
+
+protected:
+    SerializableFieldBase(SerializableObject& owner);
+};
+
+template<typename T>
+class SerializableField : public SerializableFieldBase {
+public:
+    SerializableField(SerializableObject& owner);
+
+    virtual bool serialize(BinaryFile& output) const override;
+
+    virtual bool deserialize(BinaryFile& input) override;
+
+    const T& getValue() const;
+
+    void setValue(const T& v);
+
+    SerializableField& operator=(const T& v);
+
+    SerializableField(const SerializableField&) = delete;
+
+private:
+    T value;
+};
+
+///////////////////////////// INLINE FUNCTIONS ////////////////////////////////////
+
+template<typename T>
+SerializableField<T>::SerializableField(SerializableObject& owner)
+: SerializableFieldBase(owner) {}
+
+template<typename T>
+bool SerializableField<T>::serialize(BinaryFile& output) const {
+    return Serializer<T>::serialize(output, value);
+}
+
+template<typename T>
+bool SerializableField<T>::deserialize(BinaryFile& input) {
+    return Serializer<T>::deserialize(input, value);
+}
+
+template<typename T>
+const T& SerializableField<T>::getValue() const {
+    return value;
+}
+
+template<typename T>
+void SerializableField<T>::setValue(const T& v) {
+    value = v;
+}
+
+template<typename T>
+SerializableField<T>& SerializableField<T>::operator=(const T& v) {
+    value = v;
+    return *this;
+}
+
+} // namespace bf
+} // namespace bl
+
+#endif

--- a/include/BLIB/Files/Binary/SerializableField.hpp
+++ b/include/BLIB/Files/Binary/SerializableField.hpp
@@ -10,6 +10,12 @@ namespace bf
 {
 class SerializableObject;
 
+/**
+ * @brief Base class for binary serializable fields. Do not use
+ *
+ * @ingroup BinaryFiles
+ *
+ */
 class SerializableFieldBase {
 public:
     virtual bool serialize(BinaryFile& output) const = 0;
@@ -20,21 +26,65 @@ protected:
     SerializableFieldBase(SerializableObject& owner);
 };
 
+/**
+ * @brief Template class that represents a serializable field for BinaryFile use. Strings and
+ *        integral types are supported out of the box, as well as SerializableObjects. User
+ *        defined types must either implement SerializableObject or a custom version of Serializer
+ *
+ * @tparam T The type of the field to be serialized
+ * @ingroup BinaryFiles
+ */
 template<typename T>
 class SerializableField : public SerializableFieldBase {
 public:
+    /**
+     * @brief Creates the new field and links it to its owning object
+     *
+     * @param owner The owner of this field
+     */
     SerializableField(SerializableObject& owner);
 
+    /**
+     * @brief Writes the value of this field to the given file
+     *
+     * @param output The file to write to
+     * @return True on success, false if the file is in a bad state
+     */
     virtual bool serialize(BinaryFile& output) const override;
 
+    /**
+     * @brief Populates this field value with data read from the given file
+     *
+     * @param input File to read from
+     * @return True if read successfully, false if file is in bad state
+     */
     virtual bool deserialize(BinaryFile& input) override;
 
+    /**
+     * @brief Explicit accessor for the field value
+     *
+     */
     const T& getValue() const;
 
+    /**
+     * @brief Explicit setter for the field value
+     *
+     * @param v The new value to set to
+     */
     void setValue(const T& v);
 
+    /**
+     * @brief Assigns a new value to this field
+     *
+     * @param v The value to assign to
+     * @return SerializableField& A reference to this field
+     */
     SerializableField& operator=(const T& v);
 
+    /**
+     * @brief Implicit conversion operator for convenience
+     *
+     */
     operator T() const;
 
     SerializableField(const SerializableField&) = delete;

--- a/include/BLIB/Files/Binary/SerializableObject.hpp
+++ b/include/BLIB/Files/Binary/SerializableObject.hpp
@@ -1,0 +1,39 @@
+#ifndef BLIB_FILES_BINARY_SERIALIZABLEOBJECT_HPP
+#define BLIB_FILES_BINARY_SERIALIZABLEOBJECT_HPP
+
+#include <BLIB/Files/Binary/BinaryFile.hpp>
+
+#include <vector>
+
+namespace bl
+{
+namespace bf
+{
+class SerializableFieldBase;
+
+class SerializableObject {
+public:
+    SerializableObject() = default;
+
+    SerializableObject(const SerializableObject& copy);
+
+    SerializableObject(SerializableObject&& copy);
+
+    SerializableObject& operator=(const SerializableObject& copy);
+
+    bool serialize(BinaryFile& output) const;
+
+    bool deserialize(BinaryFile& input);
+
+private:
+    std::vector<SerializableFieldBase*> fields;
+
+    void addField(SerializableFieldBase* field);
+
+    friend class SerializableFieldBase;
+};
+
+} // namespace bf
+} // namespace bl
+
+#endif

--- a/include/BLIB/Files/Binary/SerializableObject.hpp
+++ b/include/BLIB/Files/Binary/SerializableObject.hpp
@@ -11,18 +11,55 @@ namespace bf
 {
 class SerializableFieldBase;
 
+/**
+ * @brief Base class for user defined objects that can be serialized in binary files. Data fields to
+ *        be serialized should be stored as SerializableField objects
+ *
+ * @ingroup BinaryFiles
+ */
 class SerializableObject {
 public:
+    /**
+     * @brief Default constructor
+     *
+     */
     SerializableObject() = default;
 
+    /**
+     * @brief Does not copy over any fields. Care must be taken to properly construct member fields
+     *        in user defined classes
+     *
+     */
     SerializableObject(const SerializableObject& copy);
 
+    /**
+     * @brief Does not copy over any fields. Care must be taken to properly construct member fields
+     *        in user defined classes
+     *
+     */
     SerializableObject(SerializableObject&& copy);
 
+    /**
+     * @brief Does not copy over any fields. Care must be taken to properly construct member fields
+     *        in user defined classes
+     *
+     */
     SerializableObject& operator=(const SerializableObject& copy);
 
+    /**
+     * @brief Serializes this object and its contained fields to the given file
+     *
+     * @param output The file to write to
+     * @return True on success, false if data could not be written
+     */
     bool serialize(BinaryFile& output) const;
 
+    /**
+     * @brief Loads the fields of this object from the given file
+     *
+     * @param input The file to read from
+     * @return True on success, false if not all fields could be read
+     */
     bool deserialize(BinaryFile& input);
 
 private:

--- a/include/BLIB/Files/Binary/Serializer.hpp
+++ b/include/BLIB/Files/Binary/Serializer.hpp
@@ -10,28 +10,28 @@ namespace bf
 {
 template<typename T>
 struct Serializer {
-    static bool write(BinaryFile& output, const T& value);
+    static bool serialize(BinaryFile& output, const T& value);
 
-    static bool read(BinaryFile& input, T& result);
+    static bool deserialize(BinaryFile& input, T& result);
 };
 
 ///////////////////////////// INLINE FUNCTIONS ////////////////////////////////////
 
 template<typename T>
-bool Serializer<T>::write(BinaryFile& output, const T& value) {
+bool Serializer<T>::serialize(BinaryFile& output, const T& value) {
     return output.write<T>(value);
 }
 
 template<typename T>
-bool Serializer<T>::read(BinaryFile& input, T& result) {
+bool Serializer<T>::deserialize(BinaryFile& input, T& result) {
     return input.read<T>(result);
 }
 
 template<>
 struct Serializer<std::string> {
-    static bool write(BinaryFile& output, const std::string& value) { return output.write(value); }
+    static bool serialize(BinaryFile& output, const std::string& value) { return output.write(value); }
 
-    static bool read(BinaryFile& input, std::string& result) { return input.read(result); }
+    static bool deserialize(BinaryFile& input, std::string& result) { return input.read(result); }
 };
 
 template<typename U>
@@ -39,7 +39,7 @@ struct Serializer<std::vector<U>> {
     static bool serialize(BinaryFile& output, const std::vector<U>& value) {
         if (!output.write<std::uint32_t>(value.size())) return false;
         for (const U& v : value) {
-            if (!Serializer<U>::write(output, v)) return false;
+            if (!Serializer<U>::serialize(output, v)) return false;
         }
         return true;
     }
@@ -50,7 +50,7 @@ struct Serializer<std::vector<U>> {
         if (!input.read<std::uint32_t>(size)) return false;
         value.resize(size);
         for (unsigned int i = 0; i < size; ++i) {
-            if (!Serializer<U>::read(input, value[i])) return false;
+            if (!Serializer<U>::deserialize(input, value[i])) return false;
         }
         return true;
     }

--- a/include/BLIB/Files/Binary/Serializer.hpp
+++ b/include/BLIB/Files/Binary/Serializer.hpp
@@ -10,6 +10,15 @@ namespace bl
 {
 namespace bf
 {
+/**
+ * @brief Helper struct for serializing types into binary files. Integral types, strings, vector,
+ *        and SerializableObjects are supported out of the box. Specializations may be provided for
+ *        user defined types
+ *
+ * @tparam T The type to serialize
+ * @tparam bool Helper for integral specialization. Can be ignored
+ * @ingroup BinaryFiles
+ */
 template<typename T, bool = std::is_integral<T>::value>
 struct Serializer {
     static bool serialize(BinaryFile& output, const T& value);

--- a/include/BLIB/Files/Binary/Serializer.hpp
+++ b/include/BLIB/Files/Binary/Serializer.hpp
@@ -1,0 +1,73 @@
+#ifndef BLIB_FILES_BINARY_SERIALIZER_HPP
+#define BLIB_FILES_BINARY_SERIALIZER_HPP
+
+#include <BLIB/Files/Binary/BinaryFile.hpp>
+#include <BLIB/Files/Binary/SerializableObject.hpp>
+
+namespace bl
+{
+namespace bf
+{
+template<typename T>
+struct Serializer {
+    static bool write(BinaryFile& output, const T& value);
+
+    static bool read(BinaryFile& input, T& result);
+};
+
+///////////////////////////// INLINE FUNCTIONS ////////////////////////////////////
+
+template<typename T>
+bool Serializer<T>::write(BinaryFile& output, const T& value) {
+    return output.write<T>(value);
+}
+
+template<typename T>
+bool Serializer<T>::read(BinaryFile& input, T& result) {
+    return input.read<T>(result);
+}
+
+template<>
+struct Serializer<std::string> {
+    static bool write(BinaryFile& output, const std::string& value) { return output.write(value); }
+
+    static bool read(BinaryFile& input, std::string& result) { return input.read(result); }
+};
+
+template<typename U>
+struct Serializer<std::vector<U>> {
+    static bool serialize(BinaryFile& output, const std::vector<U>& value) {
+        if (!output.write<std::uint32_t>(value.size())) return false;
+        for (const U& v : value) {
+            if (!Serializer<U>::write(output, v)) return false;
+        }
+        return true;
+    }
+
+    static bool deserialize(BinaryFile& input, std::vector<U>& value) {
+        value.clear();
+        std::uint32_t size;
+        if (!input.read<std::uint32_t>(size)) return false;
+        value.resize(size);
+        for (unsigned int i = 0; i < size; ++i) {
+            if (!Serializer<U>::read(input, value[i])) return false;
+        }
+        return true;
+    }
+};
+
+template<>
+struct Serializer<SerializableObject> {
+    static bool serialize(BinaryFile& output, const SerializableObject& value) {
+        return value.serialize(output);
+    }
+
+    static bool deserialize(BinaryFile& input, SerializableObject& value) {
+        return value.deserialize(input);
+    }
+};
+
+} // namespace bf
+} // namespace bl
+
+#endif

--- a/include/BLIB/Files/Binary/VersionedBinaryFile.hpp
+++ b/include/BLIB/Files/Binary/VersionedBinaryFile.hpp
@@ -1,0 +1,77 @@
+#ifndef BLIB_FILES_BINARY_VERSIONEDBINARYFILE_HPP
+#define BLIB_FILES_BINARY_VERSIONEDBINARYFILE_HPP
+
+#include <BLIB/Files/Binary/BinaryFile.hpp>
+#include <BLIB/Util/LastVariadic.hpp>
+#include <BLIB/Util/NonCopyable.hpp>
+
+#include <cstdint>
+#include <vector>
+
+namespace bl
+{
+namespace bf
+{
+template<typename Payload>
+struct VersionedPayloadLoader {
+    virtual bool read(Payload& result, BinaryFile& input) const = 0;
+
+    virtual bool write(Payload& value, BinaryFile& output) const = 0;
+};
+
+template<typename Payload, typename DefaultLoader, typename... Versions>
+class VersionedBinaryFile : private NonCopyable {
+public:
+    using Loader = VersionedPayloadLoader<Payload>;
+
+    VersionedBinaryFile(const std::string& path, BinaryFile::OpenMode mode);
+
+    ~VersionedBinaryFile();
+
+    bool write(const Payload& payload) const;
+
+    bool read(Payload& payload) const;
+
+private:
+    static constexpr std::uint32_t NoVersion = 3257628152;
+
+    BinaryFile file;
+    const Loader* defaultLoader;
+    const std::vector<const Loader*> versions;
+};
+
+///////////////////////////// INLINE FUNCTIONS ////////////////////////////////////
+
+template<typename Payload, typename DefaultLoader, typename... Versions>
+VersionedBinaryFile<Payload, DefaultLoader, Versions...>::VersionedBinaryFile(
+    const std::string& path, BinaryFile::OpenMode mode)
+: file(path, mode)
+, defaultLoader(new DefaultLoader())
+, versions({new Versions()...}) {}
+
+template<typename Payload, typename DefaultLoader, typename... Versions>
+VersionedBinaryFile<Payload, DefaultLoader, Versions...>::~VersionedBinaryFile() {
+    delete defaultLoader;
+    for (const Loader* l : versions) { delete l; }
+}
+
+template<typename Payload, typename DefaultLoader, typename... Versions>
+bool VersionedBinaryFile<Payload, DefaultLoader, Versions...>::write(const Payload& value) const {
+    const Loader* writer = versions.empty() ? defaultLoader : versions.back();
+    return writer->write(value, file);
+}
+
+template<typename Payload, typename DefaultLoader, typename... Versions>
+bool VersionedBinaryFile<Payload, DefaultLoader, Versions...>::read(Payload& value) const {
+    std::uint32_t version = 0;
+    if (!file.peek<uint32_t>(version)) return false;
+    const Loader* loader =
+        (version == NoVersion || version >= versions.size()) ? defaultLoader : versions.at(version);
+    if (loader != defaultLoader) file.read<uint32_t>(version); // skip
+    return loader->read(value, file);
+}
+
+} // namespace bf
+} // namespace bl
+
+#endif

--- a/include/BLIB/Files/JSON/SerializableField.hpp
+++ b/include/BLIB/Files/JSON/SerializableField.hpp
@@ -108,6 +108,12 @@ public:
      */
     const T& getValue() const;
 
+    /**
+     * @brief Implicit conversion to the underlying type
+     *
+     */
+    operator T() const;
+
 private:
     T value;
 };
@@ -147,6 +153,11 @@ SerializableField<T>& SerializableField<T>::operator=(const T& v) {
 
 template<typename T>
 const T& SerializableField<T>::getValue() const {
+    return value;
+}
+
+template<typename T>
+SerializableField<T>::operator T() const {
     return value;
 }
 

--- a/include/BLIB/Util/LastVariadic.hpp
+++ b/include/BLIB/Util/LastVariadic.hpp
@@ -1,0 +1,19 @@
+#ifndef BLIB_UTIL_LASTVARIADIC_HPP
+#define BLIB_UTIL_LASTVARIADIC_HPP
+
+namespace bl
+{
+template<typename... Ts>
+class LastVariadic {
+    template<typename T>
+    struct tag {
+        using type = T;
+    };
+
+public:
+    using Last = typename decltype((tag<Ts>{}, ...))::type;
+};
+
+} // namespace bl
+
+#endif

--- a/src/Files/Binary/CMakeLists.txt
+++ b/src/Files/Binary/CMakeLists.txt
@@ -1,0 +1,4 @@
+target_sources(BLIB PRIVATE
+    SerializableField.cpp
+    SerializableObject.cpp
+)

--- a/src/Files/Binary/SerializableField.cpp
+++ b/src/Files/Binary/SerializableField.cpp
@@ -1,0 +1,11 @@
+#include <BLIB/Files/Binary/SerializableField.hpp>
+#include <BLIB/Files/Binary/SerializableObject.hpp>
+
+namespace bl
+{
+namespace bf
+{
+SerializableFieldBase::SerializableFieldBase(SerializableObject& owner) { owner.addField(this); }
+
+} // namespace bf
+} // namespace bl

--- a/src/Files/Binary/SerializableObject.cpp
+++ b/src/Files/Binary/SerializableObject.cpp
@@ -1,0 +1,31 @@
+#include <BLIB/Files/Binary/SerializableField.hpp>
+#include <BLIB/Files/Binary/SerializableObject.hpp>
+
+namespace bl
+{
+namespace bf
+{
+SerializableObject::SerializableObject(const SerializableObject&) {}
+
+SerializableObject::SerializableObject(SerializableObject&&) {}
+
+SerializableObject& SerializableObject::operator=(const SerializableObject&) { return *this; }
+
+bool SerializableObject::serialize(BinaryFile& output) const {
+    for (SerializableFieldBase* field : fields) {
+        if (!field->serialize(output)) return false;
+    }
+    return true;
+}
+
+bool SerializableObject::deserialize(BinaryFile& input) {
+    for (SerializableFieldBase* field : fields) {
+        if (!field->deserialize(input)) return false;
+    }
+    return true;
+}
+
+void SerializableObject::addField(SerializableFieldBase* field) { fields.push_back(field); }
+
+} // namespace bf
+} // namespace bl

--- a/src/Files/CMakeLists.txt
+++ b/src/Files/CMakeLists.txt
@@ -2,4 +2,5 @@ target_sources(BLIB PRIVATE
     FileUtil.cpp
 )
 
+add_subdirectory(Binary)
 add_subdirectory(JSON)

--- a/src/Media/Graphics/AnimationData.cpp
+++ b/src/Media/Graphics/AnimationData.cpp
@@ -25,7 +25,7 @@ bool AnimationData::load(const std::string& filename, const std::string& sprites
     frames.clear();
     totalLength = 0;
 
-    BinaryFile file(filename, BinaryFile::Read);
+    bf::BinaryFile file(filename, bf::BinaryFile::Read);
     const std::string path = FileUtil::getPath(filename);
 
     std::string sheet;

--- a/tests/Files/Binary/BinaryFile.t.cpp
+++ b/tests/Files/Binary/BinaryFile.t.cpp
@@ -4,15 +4,15 @@
 
 namespace bl
 {
-
+namespace bf
+{
 namespace unittest
 {
-
 TEST(BinaryFile, Integers) {
     ASSERT_TRUE(FileUtil::createDirectory("temp"));
     const std::string filename = FileUtil::genTempName("temp", "bin");
 
-    //test write
+    // test write
     {
         BinaryFile file(filename, BinaryFile::Write);
         ASSERT_TRUE(file.good());
@@ -26,7 +26,7 @@ TEST(BinaryFile, Integers) {
         ASSERT_TRUE(file.good());
     }
 
-    //test read
+    // test read
     {
         BinaryFile file(filename, BinaryFile::Read);
         ASSERT_TRUE(file.good());
@@ -69,7 +69,7 @@ TEST(BinaryFile, String) {
     ASSERT_TRUE(FileUtil::createDirectory("temp"));
     const std::string filename = FileUtil::genTempName("temp", "bin");
 
-    //write
+    // write
     {
         BinaryFile file(filename, BinaryFile::Write);
         ASSERT_TRUE(file.good());
@@ -78,7 +78,7 @@ TEST(BinaryFile, String) {
         ASSERT_TRUE(file.write("i am data!"));
     }
 
-    //read
+    // read
     {
         BinaryFile file(filename, BinaryFile::Read);
         ASSERT_TRUE(file.good());
@@ -98,7 +98,7 @@ TEST(BinaryFile, Mixed) {
     ASSERT_TRUE(FileUtil::createDirectory("temp"));
     const std::string filename = FileUtil::genTempName("temp", "bin");
 
-    //write
+    // write
     {
         BinaryFile file(filename, BinaryFile::Write);
         ASSERT_TRUE(file.write<uint32_t>(123456));
@@ -108,7 +108,7 @@ TEST(BinaryFile, Mixed) {
         ASSERT_TRUE(file.good());
     }
 
-    //read
+    // read
     {
         BinaryFile file(filename, BinaryFile::Read);
         ASSERT_TRUE(file.good());
@@ -133,6 +133,6 @@ TEST(BinaryFile, Mixed) {
     ASSERT_TRUE(FileUtil::deleteFile(filename));
 }
 
-}
-
-}
+} // namespace unittest
+} // namespace bf
+} // namespace bl

--- a/tests/Files/Binary/BinaryFile.t.cpp
+++ b/tests/Files/Binary/BinaryFile.t.cpp
@@ -8,6 +8,39 @@ namespace bf
 {
 namespace unittest
 {
+TEST(BinaryFile, Peek) {
+    ASSERT_TRUE(FileUtil::createDirectory("temp"));
+    const std::string filename = FileUtil::genTempName("temp", "bin");
+
+    // test write
+    {
+        BinaryFile file(filename, BinaryFile::Write);
+        ASSERT_TRUE(file.good());
+        ASSERT_TRUE(file.write<uint32_t>(100));
+        ASSERT_TRUE(file.good());
+    }
+
+    // test read
+    {
+        BinaryFile file(filename, BinaryFile::Read);
+        ASSERT_TRUE(file.good());
+
+        uint32_t u32 = 0;
+        ASSERT_TRUE(file.peek<uint32_t>(u32));
+        EXPECT_EQ(u32, 100);
+
+        ASSERT_TRUE(file.good());
+
+        u32 = 0;
+        ASSERT_TRUE(file.read<uint32_t>(u32));
+        EXPECT_EQ(u32, 100);
+
+        EXPECT_FALSE(file.good());
+    }
+
+    ASSERT_TRUE(FileUtil::deleteFile(filename));
+}
+
 TEST(BinaryFile, Integers) {
     ASSERT_TRUE(FileUtil::createDirectory("temp"));
     const std::string filename = FileUtil::genTempName("temp", "bin");

--- a/tests/Files/Binary/CMakeLists.txt
+++ b/tests/Files/Binary/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(BLIB.t PUBLIC
     BinaryFile.t.cpp
     SerializableField.t.cpp
+    SerializableObject.t.cpp
 )

--- a/tests/Files/Binary/CMakeLists.txt
+++ b/tests/Files/Binary/CMakeLists.txt
@@ -2,4 +2,5 @@ target_sources(BLIB.t PUBLIC
     BinaryFile.t.cpp
     SerializableField.t.cpp
     SerializableObject.t.cpp
+    VersionedBinaryFile.t.cpp
 )

--- a/tests/Files/Binary/CMakeLists.txt
+++ b/tests/Files/Binary/CMakeLists.txt
@@ -1,3 +1,4 @@
 target_sources(BLIB.t PUBLIC
     BinaryFile.t.cpp
+    SerializableField.t.cpp
 )

--- a/tests/Files/Binary/SerializableField.t.cpp
+++ b/tests/Files/Binary/SerializableField.t.cpp
@@ -1,0 +1,108 @@
+#include <BLIB/Files/Binary/SerializableField.hpp>
+#include <gtest/gtest.h>
+
+namespace bl
+{
+namespace bf
+{
+namespace unittest
+{
+TEST(BinarySerializableField, IntegralTypes) {
+    SerializableObject owner;
+    SerializableField<std::uint32_t> f1(owner);
+    SerializableField<std::int16_t> f2(owner);
+    SerializableField<bool> f3(owner);
+
+    f1.setValue(346345);
+    f2.setValue(-1234);
+    f3.setValue(true);
+
+    {
+        BinaryFile output("inttypes.bin", BinaryFile::Write);
+        ASSERT_TRUE(f1.serialize(output));
+        ASSERT_TRUE(f2.serialize(output));
+        ASSERT_TRUE(f3.serialize(output));
+    }
+
+    SerializableField<std::uint32_t> r1(owner);
+    SerializableField<std::int16_t> r2(owner);
+    SerializableField<bool> r3(owner);
+
+    {
+        BinaryFile input("inttypes.bin", BinaryFile::Read);
+        ASSERT_TRUE(r1.deserialize(input));
+        ASSERT_TRUE(r2.deserialize(input));
+        ASSERT_TRUE(r3.deserialize(input));
+    }
+
+    EXPECT_EQ(r1.getValue(), f1.getValue());
+    EXPECT_EQ(r2.getValue(), f2.getValue());
+    EXPECT_EQ(r3.getValue(), f3.getValue());
+}
+
+TEST(BinarySerializableField, String) {
+    SerializableObject owner;
+    SerializableField<std::string> field(owner);
+    field.setValue("hello world");
+
+    {
+        BinaryFile output("stringtest.bin", BinaryFile::Write);
+        ASSERT_TRUE(field.serialize(output));
+    }
+
+    SerializableField<std::string> loaded(owner);
+    {
+        BinaryFile input("stringtest.bin", BinaryFile::Read);
+        ASSERT_TRUE(loaded.deserialize(input));
+    }
+
+    EXPECT_EQ(field.getValue(), loaded.getValue());
+}
+
+TEST(BinarySerializableField, IntVector) {
+    SerializableObject owner;
+    SerializableField<std::vector<std::int16_t>> field(owner);
+    field.setValue({5, 3, 6, 435});
+
+    {
+        BinaryFile output("stringtest.bin", BinaryFile::Write);
+        ASSERT_TRUE(field.serialize(output));
+    }
+
+    SerializableField<std::vector<std::int16_t>> loaded(owner);
+    {
+        BinaryFile input("stringtest.bin", BinaryFile::Read);
+        ASSERT_TRUE(loaded.deserialize(input));
+    }
+
+    ASSERT_EQ(field.getValue().size(), loaded.getValue().size());
+    for (unsigned int i = 0; i < loaded.getValue().size(); ++i) {
+        EXPECT_EQ(field.getValue().at(i), loaded.getValue().at(i));
+    }
+}
+
+TEST(BinarySerializableField, StringVector) {
+    SerializableObject owner;
+    SerializableField<std::vector<std::string>> field(owner);
+    field.setValue({"hello", "everyone"});
+
+    {
+        BinaryFile output("stringtest.bin", BinaryFile::Write);
+        ASSERT_TRUE(field.serialize(output));
+    }
+
+    SerializableField<std::vector<std::string>> loaded(owner);
+    {
+        BinaryFile input("stringtest.bin", BinaryFile::Read);
+        ASSERT_TRUE(loaded.deserialize(input));
+    }
+
+    ASSERT_EQ(field.getValue().size(), loaded.getValue().size());
+    for (unsigned int i = 0; i < loaded.getValue().size(); ++i) {
+        EXPECT_EQ(field.getValue().at(i), loaded.getValue().at(i));
+    }
+}
+
+} // namespace unittest
+} // namespace bf
+} // namespace bl

--- a/tests/Files/Binary/SerializableObject.t.cpp
+++ b/tests/Files/Binary/SerializableObject.t.cpp
@@ -1,0 +1,92 @@
+#include <BLIB/Files/Binary.hpp>
+#include <gtest/gtest.h>
+
+namespace bl
+{
+namespace bf
+{
+namespace unittest
+{
+namespace
+{
+struct Nested : public SerializableObject {
+    SerializableField<std::int16_t> ifield;
+    SerializableField<std::string> sfield;
+
+    Nested()
+    : ifield(*this)
+    , sfield(*this) {}
+
+    Nested(std::int16_t i, const std::string& s)
+    : Nested() {
+        ifield.setValue(i);
+        sfield.setValue(s);
+    }
+
+    Nested(const Nested& copy)
+    : Nested() {
+        ifield.setValue(copy.ifield.getValue());
+        sfield.setValue(copy.sfield.getValue());
+    }
+
+    bool operator==(const Nested& right) const {
+        if (ifield.getValue() != right.ifield.getValue()) return false;
+        return sfield.getValue() == right.sfield.getValue();
+    }
+};
+
+struct Data : public SerializableObject {
+    SerializableField<std::vector<Nested>> nested;
+
+    Data()
+    : nested(*this) {}
+
+    Data(const std::vector<Nested>& v)
+    : Data() {
+        nested.setValue(v);
+    }
+};
+
+} // namespace
+
+TEST(BinarySerializableObject, SingleLevel) {
+    Nested original(52, "test object");
+
+    {
+        BinaryFile output("binaryobjectsinglelevel.bin", BinaryFile::Write);
+        ASSERT_TRUE(original.serialize(output));
+    }
+
+    Nested loaded;
+    {
+        BinaryFile input("binaryobjectsinglelevel.bin", BinaryFile::Read);
+        ASSERT_TRUE(loaded.deserialize(input));
+    }
+
+    EXPECT_EQ(original.ifield.getValue(), loaded.ifield.getValue());
+    EXPECT_EQ(original.sfield.getValue(), loaded.sfield.getValue());
+}
+
+TEST(BinarySerializableObject, NestedObjects) {
+    Data data({Nested(35, "nested 1"), Nested(923, "nested two")});
+
+    {
+        BinaryFile output("binaryobjectnested.bin", BinaryFile::Write);
+        ASSERT_TRUE(data.serialize(output));
+    }
+
+    Data loaded;
+    {
+        BinaryFile input("binaryobjectnested.bin", BinaryFile::Read);
+        ASSERT_TRUE(loaded.deserialize(input));
+    }
+
+    ASSERT_EQ(data.nested.getValue().size(), loaded.nested.getValue().size());
+    for (unsigned int i = 0; i < data.nested.getValue().size(); ++i) {
+        EXPECT_EQ(data.nested.getValue().at(i), loaded.nested.getValue().at(i));
+    }
+}
+
+} // namespace unittest
+} // namespace bf
+} // namespace bl

--- a/tests/Files/Binary/VersionedBinaryFile.t.cpp
+++ b/tests/Files/Binary/VersionedBinaryFile.t.cpp
@@ -1,0 +1,140 @@
+#include <BLIB/Files/Binary/VersionedBinaryFile.hpp>
+#include <gtest/gtest.h>
+
+namespace bl
+{
+namespace bf
+{
+namespace unittest
+{
+namespace
+{
+struct Payload {
+    int ogField;
+    std::string ogString;
+    int newInt;
+    std::string newerString;
+};
+
+struct DefaultLoader : public VersionedPayloadLoader<Payload> {
+    virtual bool read(Payload& result, BinaryFile& input) const override {
+        if (!input.read(result.ogField)) return false;
+        if (!input.read(result.ogString)) return false;
+        return true;
+    }
+
+    virtual bool write(const Payload& value, BinaryFile& output) const override {
+        if (!output.write(value.ogField)) return false;
+        if (!output.write(value.ogString)) return false;
+        return true;
+    }
+};
+
+using Version0 = DefaultLoader;
+
+struct Version1 : public Version0 {
+    virtual bool read(Payload& result, BinaryFile& input) const override {
+        if (!Version0::read(result, input)) return false;
+        if (!input.read(result.newInt)) return false;
+        return true;
+    }
+
+    virtual bool write(const Payload& value, BinaryFile& output) const override {
+        if (!Version0::write(value, output)) return false;
+        if (!output.write(value.newInt)) return false;
+        return true;
+    }
+};
+
+struct Version2 : public Version1 {
+    virtual bool read(Payload& result, BinaryFile& input) const override {
+        if (!Version1::read(result, input)) return false;
+        if (!input.read(result.newerString)) return false;
+        return true;
+    }
+
+    virtual bool write(const Payload& value, BinaryFile& output) const override {
+        if (!Version1::write(value, output)) return false;
+        if (!output.write(value.newerString)) return false;
+        return true;
+    }
+};
+
+} // namespace
+
+TEST(VersionedBinaryFile, DefaultLoader) {
+    const Payload orig = {42, "hello", 55, "goodbye"};
+    Payload loaded     = {1234, "oh no", 77, "not goodbye"};
+
+    VersionedBinaryFile<Payload, DefaultLoader> file("vbin_default.bin");
+    ASSERT_TRUE(file.write(orig));
+    ASSERT_TRUE(file.read(loaded));
+
+    EXPECT_EQ(loaded.ogField, 42);
+    EXPECT_EQ(loaded.ogString, "hello");
+    EXPECT_EQ(loaded.newInt, 77);
+    EXPECT_EQ(loaded.newerString, "not goodbye");
+}
+
+TEST(VersionedBinaryFile, MultipleVersions) {
+    const Payload orig = {42, "hello", 55, "goodbye"};
+    Payload loaded     = {1234, "oh no", 77, "not goodbye"};
+
+    VersionedBinaryFile<Payload, DefaultLoader, Version0, Version1, Version2> file(
+        "vbin_default.bin");
+    ASSERT_TRUE(file.write(orig));
+    ASSERT_TRUE(file.read(loaded));
+
+    EXPECT_EQ(loaded.ogField, orig.ogField);
+    EXPECT_EQ(loaded.ogString, orig.ogString);
+    EXPECT_EQ(loaded.newInt, orig.newInt);
+    EXPECT_EQ(loaded.newerString, orig.newerString);
+}
+
+TEST(VersionedBinaryFile, LoadOldVersion) {
+    const Payload orig = {42, "hello", 55, "goodbye"};
+    Payload loaded     = {1234, "oh no", 77, "not goodbye"};
+
+    VersionedBinaryFile<Payload, DefaultLoader, Version0, Version1> oldfile("vbin_default.bin");
+    ASSERT_TRUE(oldfile.write(orig));
+    VersionedBinaryFile<Payload, DefaultLoader, Version0, Version1, Version2> newfile(
+        "vbin_default.bin");
+    ASSERT_TRUE(newfile.read(loaded));
+
+    EXPECT_EQ(loaded.ogField, orig.ogField);
+    EXPECT_EQ(loaded.ogString, orig.ogString);
+    EXPECT_EQ(loaded.newInt, orig.newInt);
+    EXPECT_EQ(loaded.newerString, "not goodbye");
+}
+
+TEST(VersionedBinaryFile, LoadNoVersion) {
+    const Payload orig = {42, "hello", 55, "goodbye"};
+    Payload loaded     = {1234, "oh no", 77, "not goodbye"};
+
+    VersionedBinaryFile<Payload, DefaultLoader> oldfile("vbin_default.bin");
+    ASSERT_TRUE(oldfile.write(orig));
+    VersionedBinaryFile<Payload, DefaultLoader, Version0, Version1, Version2> newfile(
+        "vbin_default.bin");
+    ASSERT_TRUE(newfile.read(loaded));
+
+    EXPECT_EQ(loaded.ogField, orig.ogField);
+    EXPECT_EQ(loaded.ogString, orig.ogString);
+    EXPECT_EQ(loaded.newInt, 77);
+    EXPECT_EQ(loaded.newerString, "not goodbye");
+}
+
+TEST(VersionedBinaryFile, BadVersion) {
+    const Payload orig = {42, "hello", 55, "goodbye"};
+    Payload loaded     = {1234, "oh no", 77, "not goodbye"};
+
+    VersionedBinaryFile<Payload, DefaultLoader, Version0> oldfile("vbin_default.bin");
+    VersionedBinaryFile<Payload, DefaultLoader, Version0, Version1, Version2> newfile(
+        "vbin_default.bin");
+
+    ASSERT_TRUE(newfile.write(orig));
+    ASSERT_FALSE(oldfile.read(loaded));
+}
+
+} // namespace unittest
+} // namespace bf
+} // namespace bl

--- a/tests/Files/Binary/VersionedBinaryFile.t.cpp
+++ b/tests/Files/Binary/VersionedBinaryFile.t.cpp
@@ -66,9 +66,9 @@ TEST(VersionedBinaryFile, DefaultLoader) {
     const Payload orig = {42, "hello", 55, "goodbye"};
     Payload loaded     = {1234, "oh no", 77, "not goodbye"};
 
-    VersionedBinaryFile<Payload, DefaultLoader> file("vbin_default.bin");
-    ASSERT_TRUE(file.write(orig));
-    ASSERT_TRUE(file.read(loaded));
+    VersionedBinaryFile<Payload, DefaultLoader> file;
+    ASSERT_TRUE(file.write("vbin_default.bin", orig));
+    ASSERT_TRUE(file.read("vbin_default.bin", loaded));
 
     EXPECT_EQ(loaded.ogField, 42);
     EXPECT_EQ(loaded.ogString, "hello");
@@ -80,10 +80,9 @@ TEST(VersionedBinaryFile, MultipleVersions) {
     const Payload orig = {42, "hello", 55, "goodbye"};
     Payload loaded     = {1234, "oh no", 77, "not goodbye"};
 
-    VersionedBinaryFile<Payload, DefaultLoader, Version0, Version1, Version2> file(
-        "vbin_default.bin");
-    ASSERT_TRUE(file.write(orig));
-    ASSERT_TRUE(file.read(loaded));
+    VersionedBinaryFile<Payload, DefaultLoader, Version0, Version1, Version2> file;
+    ASSERT_TRUE(file.write("vbin_default.bin", orig));
+    ASSERT_TRUE(file.read("vbin_default.bin", loaded));
 
     EXPECT_EQ(loaded.ogField, orig.ogField);
     EXPECT_EQ(loaded.ogString, orig.ogString);
@@ -95,11 +94,10 @@ TEST(VersionedBinaryFile, LoadOldVersion) {
     const Payload orig = {42, "hello", 55, "goodbye"};
     Payload loaded     = {1234, "oh no", 77, "not goodbye"};
 
-    VersionedBinaryFile<Payload, DefaultLoader, Version0, Version1> oldfile("vbin_default.bin");
-    ASSERT_TRUE(oldfile.write(orig));
-    VersionedBinaryFile<Payload, DefaultLoader, Version0, Version1, Version2> newfile(
-        "vbin_default.bin");
-    ASSERT_TRUE(newfile.read(loaded));
+    VersionedBinaryFile<Payload, DefaultLoader, Version0, Version1> oldfile;
+    ASSERT_TRUE(oldfile.write("vbin_default.bin", orig));
+    VersionedBinaryFile<Payload, DefaultLoader, Version0, Version1, Version2> newfile;
+    ASSERT_TRUE(newfile.read("vbin_default.bin", loaded));
 
     EXPECT_EQ(loaded.ogField, orig.ogField);
     EXPECT_EQ(loaded.ogString, orig.ogString);
@@ -111,11 +109,10 @@ TEST(VersionedBinaryFile, LoadNoVersion) {
     const Payload orig = {42, "hello", 55, "goodbye"};
     Payload loaded     = {1234, "oh no", 77, "not goodbye"};
 
-    VersionedBinaryFile<Payload, DefaultLoader> oldfile("vbin_default.bin");
-    ASSERT_TRUE(oldfile.write(orig));
-    VersionedBinaryFile<Payload, DefaultLoader, Version0, Version1, Version2> newfile(
-        "vbin_default.bin");
-    ASSERT_TRUE(newfile.read(loaded));
+    VersionedBinaryFile<Payload, DefaultLoader> oldfile;
+    ASSERT_TRUE(oldfile.write("vbin_default.bin", orig));
+    VersionedBinaryFile<Payload, DefaultLoader, Version0, Version1, Version2> newfile;
+    ASSERT_TRUE(newfile.read("vbin_default.bin", loaded));
 
     EXPECT_EQ(loaded.ogField, orig.ogField);
     EXPECT_EQ(loaded.ogString, orig.ogString);
@@ -127,12 +124,11 @@ TEST(VersionedBinaryFile, BadVersion) {
     const Payload orig = {42, "hello", 55, "goodbye"};
     Payload loaded     = {1234, "oh no", 77, "not goodbye"};
 
-    VersionedBinaryFile<Payload, DefaultLoader, Version0> oldfile("vbin_default.bin");
-    VersionedBinaryFile<Payload, DefaultLoader, Version0, Version1, Version2> newfile(
-        "vbin_default.bin");
+    VersionedBinaryFile<Payload, DefaultLoader, Version0> oldfile;
+    VersionedBinaryFile<Payload, DefaultLoader, Version0, Version1, Version2> newfile;
 
-    ASSERT_TRUE(newfile.write(orig));
-    ASSERT_FALSE(oldfile.read(loaded));
+    ASSERT_TRUE(newfile.write("vbin_default.bin", orig));
+    ASSERT_FALSE(oldfile.read("vbin_default.bin", loaded));
 }
 
 } // namespace unittest

--- a/tests/Files/JSON/SerializableField.t.cpp
+++ b/tests/Files/JSON/SerializableField.t.cpp
@@ -7,7 +7,7 @@ namespace json
 {
 namespace unittest
 {
-TEST(SerializableField, Bool) {
+TEST(JsonSerializableField, Bool) {
     SerializableObject owner;
     SerializableField<bool> field("field", owner);
 
@@ -22,7 +22,7 @@ TEST(SerializableField, Bool) {
     EXPECT_EQ(field.getValue(), false);
 }
 
-TEST(SerializableField, Int) {
+TEST(JsonSerializableField, Int) {
     SerializableObject owner;
     SerializableField<int> field("field", owner);
 
@@ -32,7 +32,7 @@ TEST(SerializableField, Int) {
     EXPECT_EQ(field.getValue(), 42);
 }
 
-TEST(SerializableField, Float) {
+TEST(JsonSerializableField, Float) {
     SerializableObject owner;
     SerializableField<float> field("field", owner);
 
@@ -42,7 +42,7 @@ TEST(SerializableField, Float) {
     EXPECT_NEAR(field.getValue(), 69.42, 0.01);
 }
 
-TEST(SerializableField, String) {
+TEST(JsonSerializableField, String) {
     SerializableObject owner;
     SerializableField<std::string> field("field", owner);
 
@@ -52,7 +52,7 @@ TEST(SerializableField, String) {
     EXPECT_EQ(field.getValue(), "hello");
 }
 
-TEST(SerializableField, Vector) {
+TEST(JsonSerializableField, Vector) {
     SerializableObject owner;
     SerializableField<std::vector<int>> field("field", owner);
 
@@ -63,7 +63,7 @@ TEST(SerializableField, Vector) {
     EXPECT_EQ(field.getValue()[1], 10);
 }
 
-TEST(SerializableField, Map) {
+TEST(JsonSerializableField, Map) {
     SerializableObject owner;
     SerializableField<std::unordered_map<std::string, int>> field("field", owner);
 

--- a/tests/Files/JSON/SerializableObject.t.cpp
+++ b/tests/Files/JSON/SerializableObject.t.cpp
@@ -46,7 +46,7 @@ struct Data : public SerializableObject {
 
 } // namespace
 
-TEST(SerializableObject, SingleLevel) {
+TEST(JsonSerializableObject, SingleLevel) {
     Nested orig(true, 37.5);
     const Group encoded = orig.serialize();
 
@@ -56,7 +56,7 @@ TEST(SerializableObject, SingleLevel) {
     EXPECT_NEAR(unpacked.floatValue.getValue(), 37.5, 0.1);
 }
 
-TEST(SerializableObject, Nested) {
+TEST(JsonSerializableObject, Nested) {
     Data data(42, "string", {Nested(true, 37.5), Nested(false, 11)});
     const Group encoded = data.serialize();
 


### PR DESCRIPTION
Basic serializable objects and a primitive versioned binary file utility. May consider versioning serializable objects directly in the future via field ids. Would need to save field id and field size to file for each field (+6 bytes). Would simplify code a great deal though and allow data classes to be serialized directly instead of having many adaptor/version objects or loading functions