### PR TITLE
Binary and container refactor

### DIFF
--- a/examples/Containers/.gitignore
+++ b/examples/Containers/.gitignore
@@ -1,0 +1,1 @@
+containers

--- a/include/BLIB/Containers/Any.hpp
+++ b/include/BLIB/Containers/Any.hpp
@@ -185,9 +185,9 @@ Any<Size>& Any<Size>::operator=(const T& value) {
 
     clear();
     if constexpr (sizeof(T) < Size) {
-        object                   = inplace;
-        *static_cast<T*>(object) = value;
-        heap                     = false;
+        object = inplace;
+        new (static_cast<T*>(object)) T(value);
+        heap = false;
     }
     else {
         object = new T(value);
@@ -253,7 +253,7 @@ void Any<Size>::operate(Any<Size>& obj, const Any<Size>* copy) {
         if (obj.heap) { obj.object = new T(*static_cast<T*>(copy->object)); }
         else {
             obj.object                   = obj.inplace;
-            *static_cast<T*>(obj.object) = *static_cast<T*>(copy->object);
+            new (static_cast<T*>(obj.object)) T(*static_cast<T*>(copy->object));
         }
     }
     else {

--- a/include/BLIB/Containers/Any.hpp
+++ b/include/BLIB/Containers/Any.hpp
@@ -9,10 +9,10 @@ namespace bl
 {
 /**
  * @brief Fixed size equivalent of std::any. Specified size is for in place storage. Stored
- * objects smaller than that size will be stored in place, which allows sequential storage for
- * cache locality optimization. Larger objects will require allocations. In place storage size
- * is always used, even for types requiring allocation. Care must be taken to balance trying to
- * fit many types inplace while minimizing waste for unused inplace storage
+ *        objects smaller than that size will be stored in place, which allows sequential storage
+ *        for cache locality optimization. Larger objects will require allocations. In place storage
+ *        size is always used, even for types requiring allocation. Care must be taken to balance
+ *        trying to fit many types inplace while minimizing waste for unused inplace storage
  *
  * @tparam Size Number of bytes to use for in place storage
  * @ingroup Util
@@ -37,6 +37,15 @@ public:
     Any(const T& value);
 
     /**
+     * @brief Move constructs with the given value
+     *
+     * @tparam T Type of object to become
+     * @param value Value to store
+     */
+    template<typename T>
+    Any(T&& value);
+
+    /**
      * @brief Cleans up and destroys any contained object
      *
      */
@@ -47,7 +56,7 @@ public:
      *
      * @param copy The object to copy
      */
-    Any(const Any<Size>& copy);
+    Any(const Any& copy);
 
     /**
      * @brief Takes ownership of the data in copy
@@ -61,7 +70,7 @@ public:
      *
      * @param copy The object to copy
      */
-    Any& operator=(const Any<Size>& copy);
+    Any& operator=(const Any& copy);
 
     /**
      * @brief Constructs a new value in place
@@ -75,7 +84,7 @@ public:
 
     /**
      * @brief Copy assigns a new type and value into the Any. Copies are optimized if the type
-     * is unchanged
+     *        is unchanged
      *
      * @tparam T Type of value to become
      * @param value The value to store
@@ -86,7 +95,7 @@ public:
 
     /**
      * @brief Attempts to return the contained value as the given type. The program is aborted
-     * if the type is incorrect
+     *        if the type is incorrect
      *
      * @tparam T Type to retrieve
      * @return T& Reference to the contained value
@@ -96,7 +105,7 @@ public:
 
     /**
      * @brief Attempts to return the contained value as the given type. The program is aborted
-     * if the type is incorrect
+     *        if the type is incorrect
      *
      * @tparam T Type to retrieve
      * @return T& Reference to the contained value
@@ -144,6 +153,13 @@ Any<Size>::Any(const T& value)
 }
 
 template<unsigned int Size>
+template<typename T>
+Any<Size>::Any(T&& value)
+: Any() {
+    *this = std::forward<T>(value);
+}
+
+template<unsigned int Size>
 Any<Size>::~Any() {
     clear();
 }
@@ -168,7 +184,7 @@ Any<Size>::Any(Any<Size>&& copy)
 }
 
 template<unsigned int Size>
-Any<Size>& Any<Size>::operator=(const Any<Size>& c) {
+Any<Size>& Any<Size>::operator=(const Any& c) {
     heap  = c.heap;
     ctype = c.ctype;
     ctype(*this, &c);
@@ -252,7 +268,7 @@ void Any<Size>::operate(Any<Size>& obj, const Any<Size>* copy) {
     if (copy) {
         if (obj.heap) { obj.object = new T(*static_cast<T*>(copy->object)); }
         else {
-            obj.object                   = obj.inplace;
+            obj.object = obj.inplace;
             new (static_cast<T*>(obj.object)) T(*static_cast<T*>(copy->object));
         }
     }

--- a/include/BLIB/Containers/DynamicObjectPool.hpp
+++ b/include/BLIB/Containers/DynamicObjectPool.hpp
@@ -1,6 +1,8 @@
 #ifndef BLIB_CONTAINERS_DYNAMICOBJECTPOOL_HPP
 #define BLIB_CONTAINERS_DYNAMICOBJECTPOOL_HPP
 
+#include <cstring>
+#include <utility>
 #include <vector>
 
 namespace bl
@@ -9,7 +11,7 @@ namespace bl
  * @brief Basic object pool that may vary in size. Similar to FastEraseVector in that erase is O(1),
  *        however objects in the pool maintain their indices in the DynamicObjectPool. Object slots
  *        are marked free on erase(), reused on add(), and the pool grows in size if no slot is
- *        when add() is called
+ *        when add() is called. Objects must implement a default constructor and copy constructor.
  *
  * @tparam T Type of object to store. Works best with small POD objects
  * @ingroup Containers
@@ -145,21 +147,71 @@ public:
     std::size_t capacity() const;
 
     /**
+     * @brief Removes all objects from the pool. This invalidates all iterators
+     *
+     * @param shrinkStorage True to also clear the pool's memory, false to leave it
+     *
+     */
+    void clear(bool shrinkStorage = false);
+
+    /**
+     * @brief Shrinks the capacity of the pool down to the size
+     *
+     */
+    void shrink();
+
+    /**
      * @brief Returns whether or not the pool is empty
      *
      */
     bool empty() const;
 
 private:
-    struct Entry {
-        bool alive;
-        T data;
-        int next;
+    class Entry {
+    public:
+        Entry()
+        : _alive(false) {
+            slot.next = -1;
+        }
 
         Entry(const T& data)
-        : alive(true)
-        , data(data)
-        , next(-1) {}
+        : _alive(true) {
+            assign(data);
+        }
+
+        Entry(Entry&& copy)
+        : _alive(copy._alive) {
+            if (_alive)
+                std::memcpy(slot.buf, copy.slot.buf, std::max(sizeof(long long int), sizeof(T)));
+            copy._alive = false;
+        }
+
+        ~Entry() {
+            if (_alive) destroy();
+        }
+
+        void assign(const T& v) {
+            _alive = true;
+            new (cast()) T(v);
+        }
+
+        void destroy() {
+            cast()->~T();
+            _alive = false;
+        }
+
+        bool alive() const { return _alive; }
+
+        T* cast() { return static_cast<T*>(static_cast<void*>(slot.buf)); }
+
+        long long int& next() { return slot.next; }
+
+    private:
+        bool _alive;
+        union {
+            char buf[sizeof(T)];
+            long long int next;
+        } slot;
     };
 
     std::vector<Entry> pool;
@@ -178,14 +230,13 @@ template<typename T>
 typename DynamicObjectPool<T>::Iterator DynamicObjectPool<T>::add(const T& obj) {
     ++trackedSize;
     if (next >= 0) {
-        pool[next].alive = true;
-        pool[next].data  = obj;
-        const auto it    = next;
-        next             = pool[next].next;
+        const auto it = next;
+        next          = pool[next].next();
+        pool[it].assign(obj);
         return {pool, it};
     }
     else {
-        pool.push_back({obj});
+        pool.emplace_back(obj);
         return {pool, static_cast<long long int>(pool.size() - 1)};
     }
 }
@@ -193,9 +244,9 @@ typename DynamicObjectPool<T>::Iterator DynamicObjectPool<T>::add(const T& obj) 
 template<typename T>
 void DynamicObjectPool<T>::erase(const Iterator& i) {
     --trackedSize;
-    pool[i.i].alive = false;
-    pool[i.i].next  = -1;
-    if (next >= 0) { pool[i.i].next = next; }
+    pool[i.i].destroy();
+    pool[i.i].next() = -1;
+    if (next >= 0) { pool[i.i].next() = next; }
     next = i.i;
 }
 
@@ -235,6 +286,35 @@ bool DynamicObjectPool<T>::empty() const {
 }
 
 template<typename T>
+void DynamicObjectPool<T>::clear(bool s) {
+    trackedSize = 0;
+    if (s) {
+        pool.clear();
+        next = -1;
+    }
+    else {
+        for (unsigned int i = 0; i < pool.size(); ++i) {
+            Entry& e = pool[i];
+            if (e.alive()) {
+                e.destroy();
+                if (next >= 0) e.next() = next;
+                next = i;
+            }
+        }
+    }
+}
+
+template<typename T>
+void DynamicObjectPool<T>::shrink() {
+    std::vector<Entry> newPool;
+    newPool.reserve(trackedSize);
+    for (unsigned int i = 0; i < pool.size(); ++i) {
+        if (pool[i].alive()) { newPool.push_back(std::move(pool[i])); }
+    }
+    std::swap(pool, newPool);
+}
+
+template<typename T>
 template<typename ET>
 DynamicObjectPool<T>::IteratorType<ET>::IteratorType(std::vector<DynamicObjectPool<T>::Entry>& pool,
                                                      long long int i)
@@ -244,13 +324,13 @@ DynamicObjectPool<T>::IteratorType<ET>::IteratorType(std::vector<DynamicObjectPo
 template<typename T>
 template<typename ET>
 ET& DynamicObjectPool<T>::IteratorType<ET>::operator*() {
-    return pool[i].data;
+    return *pool[i].cast();
 }
 
 template<typename T>
 template<typename ET>
 ET* DynamicObjectPool<T>::IteratorType<ET>::operator->() {
-    return &pool[i].data;
+    return pool[i].cast();
 }
 
 template<typename T>
@@ -258,8 +338,8 @@ template<typename ET>
 typename DynamicObjectPool<T>::template IteratorType<ET>&
 DynamicObjectPool<T>::IteratorType<ET>::operator++() {
     ++i;
-    while (i < pool.size() && !pool[i].alive) { ++i; }
-    if (i == pool.size() - 1 && !pool[i].alive) ++i;
+    while (i < pool.size() && !pool[i].alive()) { ++i; }
+    if (i == pool.size() - 1 && !pool[i].alive()) ++i;
     return *this;
 }
 
@@ -268,7 +348,7 @@ template<typename ET>
 typename DynamicObjectPool<T>::template IteratorType<ET>&
 DynamicObjectPool<T>::IteratorType<ET>::operator--() {
     --i;
-    while (i > 0 && !pool[i].alive) { --i; }
+    while (i > 0 && !pool[i].alive()) { --i; }
     return *this;
 }
 

--- a/include/BLIB/Containers/DynamicObjectPool.hpp
+++ b/include/BLIB/Containers/DynamicObjectPool.hpp
@@ -212,8 +212,7 @@ private:
 
         Entry(Entry&& copy)
         : _alive(copy._alive) {
-            if (_alive)
-                std::memcpy(slot.buf, copy.slot.buf, std::max(sizeof(long long int), sizeof(T)));
+            if (_alive) { new (slot.buf) T(std::move(*copy.cast())); }
             copy._alive = false;
         }
 

--- a/include/BLIB/Containers/FastQueue.hpp
+++ b/include/BLIB/Containers/FastQueue.hpp
@@ -77,6 +77,12 @@ public:
      */
     size_t size() const;
 
+    /**
+     * @brief Clears the queue
+     *
+     */
+    void clear();
+
 private:
     std::unordered_map<T, typename std::list<T>::iterator> containedValues;
     std::list<T> queue;
@@ -156,6 +162,12 @@ bool FastQueue<T>::empty() const {
 template<typename T>
 size_t FastQueue<T>::size() const {
     return queue.size();
+}
+
+template<typename T>
+void FastQueue<T>::clear() {
+    queue.clear();
+    containedValues.clear();
 }
 
 } // namespace bl

--- a/include/BLIB/Files/Binary/BinaryFile.hpp
+++ b/include/BLIB/Files/Binary/BinaryFile.hpp
@@ -93,6 +93,14 @@ public:
     bool read(std::string& output);
 
     /**
+     * @brief Skips the given number of bytes if in Read mode
+     *
+     * @param bytes The number of bytes to skip
+     * @return True if the underlying stream is still valid, false otherwise
+     */
+    bool skip(std::size_t bytes);
+
+    /**
      * @brief Returns the status of the file handle
      *
      * @return bool Returns false if EOF is reached or the file did not exist
@@ -118,7 +126,7 @@ inline BinaryFile::BinaryFile(const std::string& path, OpenMode mode)
 
 inline BinaryFile::BinaryFile(std::iostream& s, OpenMode mode)
 : mode(mode)
-, stream(stream) {}
+, stream(s) {}
 
 template<typename T>
 typename std::enable_if<std::is_integral_v<T>, bool>::type BinaryFile::write(const T& data) {
@@ -172,6 +180,11 @@ inline bool BinaryFile::read(std::string& output) {
     char* buf = new char[size];
     stream.read(buf, size);
     output = std::string(buf, size);
+    return stream.good();
+}
+
+inline bool BinaryFile::skip(std::size_t bytes) {
+    stream.seekg(stream.tellg() + std::streamoff(bytes));
     return stream.good();
 }
 

--- a/include/BLIB/Files/Binary/BinaryFile.hpp
+++ b/include/BLIB/Files/Binary/BinaryFile.hpp
@@ -31,14 +31,19 @@ public:
     /**
      * @brief Creates a handle to the given file in the given mode
      *
+     * @param path The file to read or write
+     * @param mode The mode to operate in
+     *
      */
     BinaryFile(const std::string& path, OpenMode mode = Read);
 
     /**
-     * @brief Closes the file handle
+     * @brief Creates the binary file and writes to the given stream
      *
+     * @param stream The stream to write to
+     * @param mode The mode to operate in
      */
-    ~BinaryFile();
+    BinaryFile(std::iostream& stream, OpenMode mode = Read);
 
     /**
      * @brief Writes an integral type to the file in it's binary representation
@@ -96,24 +101,28 @@ public:
 
 private:
     const OpenMode mode;
+    std::iostream& stream;
     std::fstream handle;
 };
 
 ///////////////////////////// INLINE FUNCTIONS ////////////////////////////////////
 
 inline BinaryFile::BinaryFile(const std::string& path, OpenMode mode)
-: mode(mode) {
+: mode(mode)
+, stream(handle) {
     if (mode == Read)
         handle.open(path.c_str(), std::ios::in | std::ios::binary);
     else
         handle.open(path.c_str(), std::ios::out | std::ios::binary);
 }
 
-inline BinaryFile::~BinaryFile() { handle.close(); }
+inline BinaryFile::BinaryFile(std::iostream& s, OpenMode mode)
+: mode(mode)
+, stream(stream) {}
 
 template<typename T>
 typename std::enable_if<std::is_integral_v<T>, bool>::type BinaryFile::write(const T& data) {
-    if (!handle.good() || mode != Write) return false;
+    if (!stream.good() || mode != Write) return false;
 
     const std::size_t size = sizeof(T);
     char bytes[size];
@@ -121,54 +130,54 @@ typename std::enable_if<std::is_integral_v<T>, bool>::type BinaryFile::write(con
     if (FileUtil::isBigEndian()) {
         for (unsigned int i = 0; i < size / 2; ++i) { std::swap(bytes[i], bytes[size - i - 1]); }
     }
-    handle.write(bytes, size);
-    return handle.good();
+    stream.write(bytes, size);
+    return stream.good();
 }
 
 inline bool BinaryFile::write(const std::string& data) {
-    if (!handle.good() || mode != Write) return false;
+    if (!stream.good() || mode != Write) return false;
     if (!write<uint32_t>(data.size())) return false;
-    handle.write(data.c_str(), data.size());
-    return handle.good();
+    stream.write(data.c_str(), data.size());
+    return stream.good();
 }
 
 template<typename T>
 typename std::enable_if<std::is_integral_v<T>, bool>::type BinaryFile::read(T& output) {
-    if (!handle.good() || mode != Read) return false;
+    if (!stream.good() || mode != Read) return false;
 
     const std::size_t size = sizeof(output);
     char bytes[size];
 
     output = 0;
-    handle.read(bytes, size);
+    stream.read(bytes, size);
     if (FileUtil::isBigEndian()) {
         for (unsigned int i = 0; i < size / 2; ++i) { std::swap(bytes[i], bytes[size - i - 1]); }
     }
     std::memcpy(&output, bytes, size);
-    return handle.good();
+    return stream.good();
 }
 
 template<typename T>
 typename std::enable_if<std::is_integral_v<T>, bool>::type BinaryFile::peek(T& output) {
     const std::size_t s = sizeof(T);
     const bool r        = read<T>(output);
-    handle.seekg(handle.tellg() - std::streamoff(s));
+    stream.seekg(stream.tellg() - std::streamoff(s));
     return r;
 }
 
 inline bool BinaryFile::read(std::string& output) {
-    if (!handle.good() || mode != Read) return false;
+    if (!stream.good() || mode != Read) return false;
     uint32_t size;
     if (!read<uint32_t>(size)) return false;
     char* buf = new char[size];
-    handle.read(buf, size);
+    stream.read(buf, size);
     output = std::string(buf, size);
-    return handle.good();
+    return stream.good();
 }
 
 inline bool BinaryFile::good() {
-    const bool eof = mode == Read ? handle.peek() == EOF : false;
-    return handle.good() && !eof;
+    const bool eof = mode == Read ? stream.peek() == EOF : false;
+    return stream.good() && !eof;
 }
 
 } // namespace bf

--- a/include/BLIB/Files/Binary/SerializableObject.hpp
+++ b/include/BLIB/Files/Binary/SerializableObject.hpp
@@ -3,7 +3,7 @@
 
 #include <BLIB/Files/Binary/BinaryFile.hpp>
 
-#include <vector>
+#include <unordered_map>
 
 namespace bl
 {
@@ -62,10 +62,17 @@ public:
      */
     bool deserialize(BinaryFile& input);
 
-private:
-    std::vector<SerializableFieldBase*> fields;
+    /**
+     * @brief Returns the total size of this object when serialized, in bytes
+     *
+     * @return std::uint32_t Size of the serialized object, not including metadata
+     */
+    std::uint32_t size() const;
 
-    void addField(SerializableFieldBase* field);
+private:
+    std::unordered_map<std::uint16_t, SerializableFieldBase*> fields;
+
+    void addField(SerializableFieldBase* field, std::uint16_t id);
 
     friend class SerializableFieldBase;
 };

--- a/src/Files/Binary/SerializableField.cpp
+++ b/src/Files/Binary/SerializableField.cpp
@@ -5,7 +5,7 @@ namespace bl
 {
 namespace bf
 {
-SerializableFieldBase::SerializableFieldBase(SerializableObject& owner) { owner.addField(this); }
+SerializableFieldBase::SerializableFieldBase(SerializableObject& owner, std::uint16_t id) { owner.addField(this, id); }
 
 } // namespace bf
 } // namespace bl

--- a/src/Files/Binary/SerializableObject.cpp
+++ b/src/Files/Binary/SerializableObject.cpp
@@ -1,5 +1,6 @@
 #include <BLIB/Files/Binary/SerializableField.hpp>
 #include <BLIB/Files/Binary/SerializableObject.hpp>
+#include <BLIB/Logging.hpp>
 
 namespace bl
 {
@@ -12,20 +13,47 @@ SerializableObject::SerializableObject(SerializableObject&&) {}
 SerializableObject& SerializableObject::operator=(const SerializableObject&) { return *this; }
 
 bool SerializableObject::serialize(BinaryFile& output) const {
-    for (SerializableFieldBase* field : fields) {
-        if (!field->serialize(output)) return false;
+    if (!output.write<std::uint16_t>(fields.size())) return false;
+    for (const auto& it : fields) {
+        if (!output.write<std::uint16_t>(it.first)) return false;
+        if (!output.write<std::uint32_t>(it.second->size())) return false;
+        if (!it.second->serialize(output)) return false;
     }
     return true;
 }
 
 bool SerializableObject::deserialize(BinaryFile& input) {
-    for (SerializableFieldBase* field : fields) {
-        if (!field->deserialize(input)) return false;
+    std::uint16_t nfields = 0;
+    if (!input.read<std::uint16_t>(nfields)) return false;
+    for (std::uint16_t i = 0; i < nfields; ++i) {
+        std::uint16_t fid = 0;
+        std::uint32_t fs  = 0;
+        if (!input.read<std::uint16_t>(fid)) return false;
+        if (!input.read<std::uint32_t>(fs)) return false;
+        auto it = fields.find(fid);
+        if (it != fields.end()) {
+            if (!it->second->deserialize(input)) return false;
+        }
+        else {
+            if (!input.skip(fs)) return false;
+        }
     }
     return true;
 }
 
-void SerializableObject::addField(SerializableFieldBase* field) { fields.push_back(field); }
+void SerializableObject::addField(SerializableFieldBase* field, std::uint16_t id) {
+    if (fields.find(id) != fields.end()) {
+        BL_LOG_ERROR << "SerializableObject has duplicate field id: " << id;
+        return;
+    }
+    fields[id] = field;
+}
+
+std::uint32_t SerializableObject::size() const {
+    std::uint32_t s;
+    for (const auto& it : fields) { s += it.second->size(); }
+    return s;
+}
 
 } // namespace bf
 } // namespace bl

--- a/tests/Containers/DynamicObjectPool.t.cpp
+++ b/tests/Containers/DynamicObjectPool.t.cpp
@@ -5,6 +5,22 @@ namespace bl
 {
 namespace unittest
 {
+namespace
+{
+struct Dummy {
+    Dummy()
+    : d(nullptr) {}
+
+    ~Dummy() {
+        if (d) *d = true;
+    }
+
+    void set(bool* _d) { d = _d; }
+
+    bool* d;
+};
+} // namespace
+
 TEST(DynamicObjectPool, Empty) {
     DynamicObjectPool<int> pool;
     EXPECT_TRUE(pool.empty());
@@ -90,6 +106,84 @@ TEST(DynamicObjectPool, Reuse) {
     EXPECT_EQ(*(pool.begin() + 2), 3);
     EXPECT_EQ(*(pool.begin() + 3), 20);
     EXPECT_EQ(*(pool.begin() + 4), 5);
+}
+
+TEST(DynamicObjectPool, Destructor) {
+    DynamicObjectPool<Dummy> pool;
+    bool dcalls[] = {false, false, false};
+
+    pool.add({});
+    pool.add({});
+    pool.add({});
+
+    pool.begin()->set(&dcalls[0]);
+    (++pool.begin())->set(&dcalls[1]);
+    (pool.begin() + 2)->set(&dcalls[2]);
+
+    ASSERT_FALSE(dcalls[0]);
+    ASSERT_FALSE(dcalls[1]);
+    ASSERT_FALSE(dcalls[2]);
+
+    pool.erase(pool.begin() + 1);
+    ASSERT_FALSE(dcalls[0]);
+    ASSERT_TRUE(dcalls[1]);
+    ASSERT_FALSE(dcalls[2]);
+
+    pool.clear();
+    ASSERT_EQ(pool.size(), 0);
+    EXPECT_EQ(pool.capacity(), 3);
+    ASSERT_TRUE(dcalls[0]);
+    ASSERT_TRUE(dcalls[1]);
+    ASSERT_TRUE(dcalls[2]);
+
+    pool.clear(true);
+    EXPECT_EQ(pool.capacity(), 0);
+}
+
+TEST(DynamicObjectPool, Shrink) {
+    DynamicObjectPool<int> pool;
+
+    pool.add(1);
+    pool.add(2);
+    pool.add(3);
+    pool.erase(pool.begin() + 1);
+
+    ASSERT_EQ(pool.size(), 2);
+    ASSERT_EQ(pool.capacity(), 3);
+
+    pool.shrink();
+    EXPECT_EQ(pool.capacity(), 2);
+    EXPECT_EQ(*pool.begin(), 1);
+    EXPECT_EQ(*(pool.begin() + 1), 3);
+}
+
+TEST(DynamicObjectPool, ShrinkDestructor) {
+    DynamicObjectPool<Dummy> pool;
+    bool dcalls[] = {false, false, false};
+
+    pool.add({});
+    pool.add({});
+    pool.add({});
+
+    pool.begin()->set(&dcalls[0]);
+    (++pool.begin())->set(&dcalls[1]);
+    (pool.begin() + 2)->set(&dcalls[2]);
+
+    ASSERT_FALSE(dcalls[0]);
+    ASSERT_FALSE(dcalls[1]);
+    ASSERT_FALSE(dcalls[2]);
+
+    pool.erase(pool.begin() + 1);
+    ASSERT_FALSE(dcalls[0]);
+    ASSERT_TRUE(dcalls[1]);
+    ASSERT_FALSE(dcalls[2]);
+
+    pool.shrink();
+    EXPECT_EQ(pool.capacity(), 2);
+
+    ASSERT_FALSE(dcalls[0]);
+    ASSERT_TRUE(dcalls[1]);
+    ASSERT_FALSE(dcalls[2]);
 }
 
 } // namespace unittest

--- a/tests/Containers/DynamicObjectPool.t.cpp
+++ b/tests/Containers/DynamicObjectPool.t.cpp
@@ -1,4 +1,5 @@
 #include <BLIB/Containers/DynamicObjectPool.hpp>
+#include <BLIB/Containers/Any.hpp>
 #include <gtest/gtest.h>
 
 namespace bl
@@ -27,6 +28,14 @@ struct Dummy {
 
     bool* d;
 };
+
+struct Data {
+    int value;
+
+    Data() = default;
+    Data(int i) : value(i) {}
+};
+
 } // namespace
 
 TEST(DynamicObjectPool, Empty) {
@@ -208,6 +217,30 @@ TEST(DynamicObjectPool, EmplaceAndMove) {
     pool.clear();
     EXPECT_TRUE(dcalls[0]);
     EXPECT_TRUE(dcalls[1]);
+}
+
+TEST(DynamicObjectPool, MultipleObjects) {
+    DynamicObjectPool<Data> pool;
+
+    pool.emplace(5);
+    pool.emplace(10);
+    pool.add({15});
+
+    EXPECT_EQ(pool.begin()->value, 5);
+    EXPECT_EQ((pool.begin()+1)->value, 10);
+    EXPECT_EQ((pool.begin()+2)->value, 15);
+}
+
+TEST(DynamicObjectPool, Any) {
+    DynamicObjectPool<Any<32>> pool;
+
+    pool.add(Data(5));
+    pool.add(Data(10));
+
+    Any<32>& temp = *pool.begin();
+    auto val = temp.get<Data>();
+    EXPECT_EQ(pool.begin()->get<Data>().value, 5);
+    EXPECT_EQ((pool.begin()+1)->get<Data>().value, 10);
 }
 
 } // namespace unittest

--- a/tests/Containers/DynamicObjectPool.t.cpp
+++ b/tests/Containers/DynamicObjectPool.t.cpp
@@ -11,6 +11,14 @@ struct Dummy {
     Dummy()
     : d(nullptr) {}
 
+    Dummy(bool* d)
+    : d(d) {}
+
+    Dummy(Dummy&& c)
+    : d(c.d) {
+        c.d = nullptr;
+    }
+
     ~Dummy() {
         if (d) *d = true;
     }
@@ -184,6 +192,22 @@ TEST(DynamicObjectPool, ShrinkDestructor) {
     ASSERT_FALSE(dcalls[0]);
     ASSERT_TRUE(dcalls[1]);
     ASSERT_FALSE(dcalls[2]);
+}
+
+TEST(DynamicObjectPool, EmplaceAndMove) {
+    DynamicObjectPool<Dummy> pool;
+    bool dcalls[] = {false, false};
+
+    Dummy d(&dcalls[0]);
+    pool.add(std::move(d));
+    pool.emplace(&dcalls[1]);
+
+    ASSERT_FALSE(dcalls[0]);
+    ASSERT_FALSE(dcalls[1]);
+
+    pool.clear();
+    EXPECT_TRUE(dcalls[0]);
+    EXPECT_TRUE(dcalls[1]);
 }
 
 } // namespace unittest

--- a/tests/Containers/RingBuffer.t.cpp
+++ b/tests/Containers/RingBuffer.t.cpp
@@ -5,6 +5,28 @@ namespace bl
 {
 namespace unittest
 {
+namespace
+{
+struct Dummy {
+    Dummy()
+    : d(nullptr) {}
+
+    Dummy(Dummy&& c)
+    : d(c.d) {
+        c.d = nullptr;
+    }
+
+    Dummy(bool* d)
+    : d(d) {}
+
+    ~Dummy() {
+        if (d) *d = true;
+    }
+
+    bool* d;
+};
+} // namespace
+
 TEST(RingBuffer, PushAndPop) {
     RingBuffer<int> buffer(5);
 
@@ -88,6 +110,28 @@ TEST(RingBuffer, PopEmpty) {
     EXPECT_EQ(buffer[1], 7);
     EXPECT_EQ(buffer.front(), 10);
     EXPECT_EQ(buffer.back(), 7);
+}
+
+TEST(RingBuffer, ClearDestructor) {
+    RingBuffer<Dummy> buffer(2);
+    bool dcalls[] = {false, false, false};
+
+    buffer.emplace_back(&dcalls[0]);
+    buffer.emplace_back(&dcalls[1]);
+    Dummy d(&dcalls[2]);
+    buffer.push_back(std::move(d));
+
+    ASSERT_TRUE(dcalls[0]);
+    ASSERT_FALSE(dcalls[1]);
+    ASSERT_FALSE(dcalls[2]);
+
+    EXPECT_EQ(buffer.size(), 2);
+    buffer.clear();
+    EXPECT_EQ(buffer.size(), 0);
+
+    ASSERT_TRUE(dcalls[0]);
+    ASSERT_TRUE(dcalls[1]);
+    ASSERT_TRUE(dcalls[2]);
 }
 
 } // namespace unittest

--- a/tests/Entities/Registry.t.cpp
+++ b/tests/Entities/Registry.t.cpp
@@ -209,7 +209,7 @@ TEST(Registry, PredefinedEntity) {
     Registry registry;
     Entity e1 = registry.createEntity();
     EXPECT_FALSE(registry.createEntity(e1));
-    EXPECT_TRUE(registry.createEntity(e1+1));
+    EXPECT_TRUE(registry.createEntity(e1 + 1));
 }
 
 } // namespace unittest

--- a/tests/Files/Binary/SerializableField.t.cpp
+++ b/tests/Files/Binary/SerializableField.t.cpp
@@ -9,9 +9,9 @@ namespace unittest
 {
 TEST(BinarySerializableField, IntegralTypes) {
     SerializableObject owner;
-    SerializableField<std::uint32_t> f1(owner);
-    SerializableField<std::int16_t> f2(owner);
-    SerializableField<bool> f3(owner);
+    SerializableField<1, std::uint32_t> f1(owner);
+    SerializableField<2, std::int16_t> f2(owner);
+    SerializableField<3, bool> f3(owner);
 
     f1.setValue(346345);
     f2.setValue(-1234);
@@ -24,9 +24,9 @@ TEST(BinarySerializableField, IntegralTypes) {
         ASSERT_TRUE(f3.serialize(output));
     }
 
-    SerializableField<std::uint32_t> r1(owner);
-    SerializableField<std::int16_t> r2(owner);
-    SerializableField<bool> r3(owner);
+    SerializableField<1, std::uint32_t> r1(owner);
+    SerializableField<2, std::int16_t> r2(owner);
+    SerializableField<3, bool> r3(owner);
 
     {
         BinaryFile input("inttypes.bin", BinaryFile::Read);
@@ -42,7 +42,7 @@ TEST(BinarySerializableField, IntegralTypes) {
 
 TEST(BinarySerializableField, String) {
     SerializableObject owner;
-    SerializableField<std::string> field(owner);
+    SerializableField<1, std::string> field(owner);
     field.setValue("hello world");
 
     {
@@ -50,7 +50,7 @@ TEST(BinarySerializableField, String) {
         ASSERT_TRUE(field.serialize(output));
     }
 
-    SerializableField<std::string> loaded(owner);
+    SerializableField<1, std::string> loaded(owner);
     {
         BinaryFile input("stringtest.bin", BinaryFile::Read);
         ASSERT_TRUE(loaded.deserialize(input));
@@ -61,7 +61,7 @@ TEST(BinarySerializableField, String) {
 
 TEST(BinarySerializableField, IntVector) {
     SerializableObject owner;
-    SerializableField<std::vector<std::int16_t>> field(owner);
+    SerializableField<1, std::vector<std::int16_t>> field(owner);
     field.setValue({5, 3, 6, 435});
 
     {
@@ -69,7 +69,7 @@ TEST(BinarySerializableField, IntVector) {
         ASSERT_TRUE(field.serialize(output));
     }
 
-    SerializableField<std::vector<std::int16_t>> loaded(owner);
+    SerializableField<1, std::vector<std::int16_t>> loaded(owner);
     {
         BinaryFile input("stringtest.bin", BinaryFile::Read);
         ASSERT_TRUE(loaded.deserialize(input));
@@ -83,7 +83,7 @@ TEST(BinarySerializableField, IntVector) {
 
 TEST(BinarySerializableField, StringVector) {
     SerializableObject owner;
-    SerializableField<std::vector<std::string>> field(owner);
+    SerializableField<1, std::vector<std::string>> field(owner);
     field.setValue({"hello", "everyone"});
 
     {
@@ -91,7 +91,7 @@ TEST(BinarySerializableField, StringVector) {
         ASSERT_TRUE(field.serialize(output));
     }
 
-    SerializableField<std::vector<std::string>> loaded(owner);
+    SerializableField<1, std::vector<std::string>> loaded(owner);
     {
         BinaryFile input("stringtest.bin", BinaryFile::Read);
         ASSERT_TRUE(loaded.deserialize(input));

--- a/tests/Files/Binary/SerializableObject.t.cpp
+++ b/tests/Files/Binary/SerializableObject.t.cpp
@@ -10,8 +10,8 @@ namespace unittest
 namespace
 {
 struct Nested : public SerializableObject {
-    SerializableField<std::int16_t> ifield;
-    SerializableField<std::string> sfield;
+    SerializableField<1, std::int16_t> ifield;
+    SerializableField<2, std::string> sfield;
 
     Nested()
     : ifield(*this)
@@ -29,6 +29,12 @@ struct Nested : public SerializableObject {
         sfield.setValue(copy.sfield.getValue());
     }
 
+    Nested& operator=(const Nested& c) {
+        ifield.setValue(c.ifield.getValue());
+        sfield.setValue(c.sfield.getValue());
+        return *this;
+    }
+
     bool operator==(const Nested& right) const {
         if (ifield.getValue() != right.ifield.getValue()) return false;
         return sfield.getValue() == right.sfield.getValue();
@@ -36,7 +42,7 @@ struct Nested : public SerializableObject {
 };
 
 struct Data : public SerializableObject {
-    SerializableField<std::vector<Nested>> nested;
+    SerializableField<1, std::vector<Nested>> nested;
 
     Data()
     : nested(*this) {}
@@ -44,6 +50,21 @@ struct Data : public SerializableObject {
     Data(const std::vector<Nested>& v)
     : Data() {
         nested.setValue(v);
+    }
+};
+
+struct DataV2 : public SerializableObject {
+    SerializableField<1, std::vector<Nested>> nested;
+    SerializableField<2, std::string> newString;
+
+    DataV2()
+    : nested(*this)
+    , newString(*this) {}
+
+    DataV2(const std::vector<Nested>& v, const std::string& s)
+    : DataV2() {
+        nested.setValue(v);
+        newString = s;
     }
 };
 
@@ -78,6 +99,52 @@ TEST(BinarySerializableObject, NestedObjects) {
     Data loaded;
     {
         BinaryFile input("binaryobjectnested.bin", BinaryFile::Read);
+        ASSERT_TRUE(loaded.deserialize(input));
+    }
+
+    ASSERT_EQ(data.nested.getValue().size(), loaded.nested.getValue().size());
+    for (unsigned int i = 0; i < data.nested.getValue().size(); ++i) {
+        EXPECT_EQ(data.nested.getValue().at(i), loaded.nested.getValue().at(i));
+    }
+}
+
+TEST(BinarySerializableObject, LoadOldVersion) {
+    Data old({Nested(35, "nested 1"), Nested(923, "nested two")});
+
+    {
+        BinaryFile output("binaryobjectnested.bin", BinaryFile::Write);
+        ASSERT_TRUE(old.serialize(output));
+    }
+
+    DataV2 loaded;
+    loaded.newString = "unchanged";
+    {
+        BinaryFile input("binaryobjectnested.bin", BinaryFile::Read);
+        ASSERT_TRUE(loaded.deserialize(input));
+    }
+
+    EXPECT_EQ(loaded.newString.getValue(), "unchanged");
+    ASSERT_EQ(old.nested.getValue().size(), loaded.nested.getValue().size());
+    for (unsigned int i = 0; i < old.nested.getValue().size(); ++i) {
+        EXPECT_EQ(old.nested.getValue().at(i), loaded.nested.getValue().at(i));
+    }
+}
+
+TEST(BinarySerializableObject, LoadNewVersion) {
+    DataV2 data({Nested(35, "nested 1"), Nested(923, "nested two")}, "mystring");
+    std::string buffer;
+
+    {
+        std::stringstream ss;
+        BinaryFile output(ss, BinaryFile::Write);
+        ASSERT_TRUE(data.serialize(output));
+        buffer = ss.str();
+    }
+
+    Data loaded;
+    {
+        std::stringstream ss(buffer);
+        BinaryFile input(ss, BinaryFile::Read);
         ASSERT_TRUE(loaded.deserialize(input));
     }
 


### PR DESCRIPTION
- Add field versioning to `SerializableObject` in binary files package
- Add proper move semantics to several containers
- Call destructors at proper times in several containers
- Use placement new for proper construction in several containers