### PR TITLE
Gui patch

### DIFF
--- a/include/BLIB/Interfaces/GUI/Elements/Notebook.hpp
+++ b/include/BLIB/Interfaces/GUI/Elements/Notebook.hpp
@@ -20,7 +20,7 @@ namespace gui
 class Notebook : public Container {
 public:
     typedef std::shared_ptr<Notebook> Ptr;
-    typedef std::function<void()> PageSelectedCb;
+    typedef std::function<void()> PageChangedCb;
 
     virtual ~Notebook();
 
@@ -38,12 +38,24 @@ public:
      *
      */
     struct Page {
-        const std::string name; /// The internal name of the page
-        Label::Ptr label;       /// The label at the top of the notebook
-        Element::Ptr content;   /// Any element that is the actual page content
+        /// The internal name of the page
+        const std::string name;
+
+        /// The label at the top of the notebook
+        Label::Ptr label;
+
+        /// Any element that is the actual page content
+        Element::Ptr content;
+
+        /// Callback to trigger when the page is opened
+        PageChangedCb onOpen;
+
+        /// Callback to trigger when the page is closed
+        PageChangedCb onClose;
 
     private:
-        Page(const std::string& name, Label::Ptr label, Element::Ptr content);
+        Page(const std::string& name, Label::Ptr label, Element::Ptr content,
+             const PageChangedCb& onOpen, const PageChangedCb& onClose);
 
         friend class Notebook;
     };
@@ -54,11 +66,12 @@ public:
      * @param name The name of the page. This is not visible anywhere
      * @param title The title to put in the button
      * @param content The content to put in the notebook when the page is selected
-     * @param cb Callback to trigger when this page is selected
+     * @param onOpen Callback to trigger when this page is selected
+     * @param onClose Callback to trigger when this page is left
      */
     void addPage(
         const std::string& name, const std::string& title, Element::Ptr content,
-        const PageSelectedCb& cb = []() {});
+        const PageChangedCb& onOpen = []() {}, const PageChangedCb& onClose = []() {});
 
     /**
      * @brief Returns the active page itself

--- a/include/BLIB/Interfaces/GUI/Elements/Notebook.hpp
+++ b/include/BLIB/Interfaces/GUI/Elements/Notebook.hpp
@@ -20,6 +20,7 @@ namespace gui
 class Notebook : public Container {
 public:
     typedef std::shared_ptr<Notebook> Ptr;
+    typedef std::function<void()> PageSelectedCb;
 
     virtual ~Notebook();
 
@@ -52,9 +53,12 @@ public:
      *
      * @param name The name of the page. This is not visible anywhere
      * @param title The title to put in the button
-     * @param content
+     * @param content The content to put in the notebook when the page is selected
+     * @param cb Callback to trigger when this page is selected
      */
-    void addPage(const std::string& name, const std::string& title, Element::Ptr content);
+    void addPage(
+        const std::string& name, const std::string& title, Element::Ptr content,
+        const PageSelectedCb& cb = []() {});
 
     /**
      * @brief Returns the active page itself

--- a/include/BLIB/Interfaces/GUI/RawEvent.hpp
+++ b/include/BLIB/Interfaces/GUI/RawEvent.hpp
@@ -9,7 +9,7 @@ namespace bl
 namespace gui
 {
 /**
- * @brief Raw window event that can be propogated in response to window events
+ * @brief Raw window event that can be propagated in response to window events
  *
  * @ingroup GUI
  *
@@ -22,8 +22,7 @@ struct RawEvent {
      * @param mousePos The global mouse position to use if none in the event
      * @param transform The transform to apply to the mouse position
      */
-    RawEvent(const sf::Event& event, const sf::Vector2f& mousePos,
-             const sf::Transform& transform);
+    RawEvent(const sf::Event& event, const sf::Vector2f& mousePos, const sf::Transform& transform);
 
     /**
      * @brief Create a new RawEvent with the local position transformed to the new

--- a/src/Interfaces/GUI/Elements/ComboBox.cpp
+++ b/src/Interfaces/GUI/Elements/ComboBox.cpp
@@ -125,8 +125,8 @@ void ComboBox::doRender(sf::RenderTarget& target, sf::RenderStates states,
     const sf::View oldView = target.getView();
     sf::IntRect region     = getAcquisition();
     region.height += options.size() * labelSize.y;
-    renderer.renderComboBox(target, states, *this, labelSize, opened ? options.size() : 0, moused);
     target.setView(computeView(target, region, false));
+    renderer.renderComboBox(target, states, *this, labelSize, opened ? options.size() : 0, moused);
     renderChildrenRawFiltered(target, states, renderer, {});
     target.setView(oldView);
 }

--- a/src/Interfaces/GUI/Elements/Label.cpp
+++ b/src/Interfaces/GUI/Elements/Label.cpp
@@ -6,11 +6,6 @@ namespace bl
 {
 namespace gui
 {
-namespace
-{
-constexpr int Padding = 3;
-}
-
 Label::Ptr Label::create(const std::string& text, const std::string& group, const std::string& id) {
     return Ptr(new Label(text, group, id));
 }
@@ -37,10 +32,8 @@ void Label::doRender(sf::RenderTarget& target, sf::RenderStates states,
 
 sf::Vector2i Label::minimumRequisition() const {
     return {
-        static_cast<int>(renderText.getGlobalBounds().width + renderText.getGlobalBounds().left) +
-            Padding * 2,
-        static_cast<int>(renderText.getGlobalBounds().height + renderText.getGlobalBounds().top) +
-            Padding * 2};
+        static_cast<int>(renderText.getGlobalBounds().width + renderText.getGlobalBounds().left),
+        static_cast<int>(renderText.getGlobalBounds().height + renderText.getGlobalBounds().top)};
 }
 
 void Label::settingsChanged() {

--- a/src/Interfaces/GUI/Elements/Notebook.cpp
+++ b/src/Interfaces/GUI/Elements/Notebook.cpp
@@ -115,10 +115,10 @@ sf::Vector2i Notebook::minimumRequisition() const {
 void Notebook::onAcquisition() {
     Packer::manuallyPackElement(tabArea,
                                 {0, 0, getAcquisition().width, tabArea->getRequisition().y});
-    contentArea = {0,
-                   tabArea->getRequisition().y,
-                   getAcquisition().width,
-                   getAcquisition().height - tabArea->getRequisition().y};
+    contentArea = {2,
+                   tabArea->getRequisition().y + 2,
+                   getAcquisition().width - 4,
+                   getAcquisition().height - tabArea->getRequisition().y - 4};
     if (activePage < pages.size())
         Packer::manuallyPackElement(pages[activePage]->content, contentArea);
 }

--- a/src/Interfaces/GUI/Elements/Notebook.cpp
+++ b/src/Interfaces/GUI/Elements/Notebook.cpp
@@ -41,7 +41,7 @@ void Notebook::addPage(const std::string& name, const std::string& title, Elemen
         pages.back()->content->skipPacking(true);
         pages.back()->content->setVisible(false);
         add(pages.back()->content);
-        tabArea->pack(pages.back()->label, true, true);
+        tabArea->pack(pages.back()->label, false, true);
         pages.back()
             ->label->getSignal(Action::LeftClicked)
             .willAlwaysCall(std::bind(&Notebook::pageClicked, this, pages.back()));

--- a/src/Interfaces/GUI/Elements/Notebook.cpp
+++ b/src/Interfaces/GUI/Elements/Notebook.cpp
@@ -37,8 +37,9 @@ Notebook::Page::Page(const std::string& name, Label::Ptr label, Element::Ptr con
 void Notebook::addPage(const std::string& name, const std::string& title, Element::Ptr content,
                        const PageChangedCb& onOpen, const PageChangedCb& onClose) {
     if (pageMap.find(name) == pageMap.end()) {
-        pages.push_back(new Page(
-            name, Label::create(title, group(), id() + "-tab-" + name), content, onOpen, onClose));
+        Label::Ptr label = Label::create(title, group(), id() + "-tab-" + name);
+        label->setRequisition(label->getRequisition() + sf::Vector2i(6, 6));
+        pages.push_back(new Page(name, label, content, onOpen, onClose));
         pageMap[name] = std::make_pair(pages.size() - 1, pages.back());
 
         pages.back()->content->skipPacking(true);
@@ -140,13 +141,13 @@ void Notebook::makePageActive(unsigned int i) {
     if (i < pages.size()) {
         if (activePage < pages.size()) {
             pages[activePage]->content->setVisible(false, false);
-            pages[activePage]->onClose();
+            if (i != activePage) pages[activePage]->onClose();
         }
-        activePage = i;
         pages[i]->content->setVisible(true, false);
         pages[i]->content->moveToTop();
         Packer::manuallyPackElement(pages[i]->content, contentArea);
-        pages[i]->onOpen();
+        if (i != activePage) pages[i]->onOpen();
+        activePage = i;
     }
 }
 

--- a/src/Interfaces/GUI/Elements/Notebook.cpp
+++ b/src/Interfaces/GUI/Elements/Notebook.cpp
@@ -40,6 +40,8 @@ void Notebook::addPage(const std::string& name, const std::string& title, Elemen
 
         pages.back()->content->skipPacking(true);
         pages.back()->content->setVisible(false);
+        pages.back()->content->setExpandsWidth(true);
+        pages.back()->content->setExpandsHeight(true);
         add(pages.back()->content);
         tabArea->pack(pages.back()->label, false, true);
         pages.back()

--- a/src/Interfaces/GUI/Elements/Notebook.cpp
+++ b/src/Interfaces/GUI/Elements/Notebook.cpp
@@ -31,7 +31,8 @@ Notebook::Page::Page(const std::string& name, Label::Ptr label, Element::Ptr con
 , label(label)
 , content(content) {}
 
-void Notebook::addPage(const std::string& name, const std::string& title, Element::Ptr content) {
+void Notebook::addPage(const std::string& name, const std::string& title, Element::Ptr content,
+                       const PageSelectedCb& cb) {
     if (pageMap.find(name) == pageMap.end()) {
         pages.push_back(
             new Page(name, Label::create(title, group(), id() + "-tab-" + name), content));
@@ -44,6 +45,10 @@ void Notebook::addPage(const std::string& name, const std::string& title, Elemen
         pages.back()
             ->label->getSignal(Action::LeftClicked)
             .willAlwaysCall(std::bind(&Notebook::pageClicked, this, pages.back()));
+
+        auto cbWrapper = [cb](const Action&, Element*) { cb(); };
+        pages.back()->label->getSignal(Action::LeftClicked).willAlwaysCall(cbWrapper);
+
         if (pages.size() == 1) makePageActive(0);
     }
 }

--- a/src/Interfaces/GUI/Elements/Notebook.cpp
+++ b/src/Interfaces/GUI/Elements/Notebook.cpp
@@ -26,16 +26,19 @@ Notebook::~Notebook() {
     while (!pages.empty()) removePageByIndex(0);
 }
 
-Notebook::Page::Page(const std::string& name, Label::Ptr label, Element::Ptr content)
+Notebook::Page::Page(const std::string& name, Label::Ptr label, Element::Ptr content,
+                     const Notebook::PageChangedCb& op, const Notebook::PageChangedCb& oc)
 : name(name)
 , label(label)
-, content(content) {}
+, content(content)
+, onOpen(op)
+, onClose(oc) {}
 
 void Notebook::addPage(const std::string& name, const std::string& title, Element::Ptr content,
-                       const PageSelectedCb& cb) {
+                       const PageChangedCb& onOpen, const PageChangedCb& onClose) {
     if (pageMap.find(name) == pageMap.end()) {
-        pages.push_back(
-            new Page(name, Label::create(title, group(), id() + "-tab-" + name), content));
+        pages.push_back(new Page(
+            name, Label::create(title, group(), id() + "-tab-" + name), content, onOpen, onClose));
         pageMap[name] = std::make_pair(pages.size() - 1, pages.back());
 
         pages.back()->content->skipPacking(true);
@@ -47,9 +50,6 @@ void Notebook::addPage(const std::string& name, const std::string& title, Elemen
         pages.back()
             ->label->getSignal(Action::LeftClicked)
             .willAlwaysCall(std::bind(&Notebook::pageClicked, this, pages.back()));
-
-        auto cbWrapper = [cb](const Action&, Element*) { cb(); };
-        pages.back()->label->getSignal(Action::LeftClicked).willAlwaysCall(cbWrapper);
 
         if (pages.size() == 1) makePageActive(0);
     }
@@ -138,11 +138,15 @@ void Notebook::pageClicked(Page* page) {
 
 void Notebook::makePageActive(unsigned int i) {
     if (i < pages.size()) {
-        if (activePage < pages.size()) pages[activePage]->content->setVisible(false, false);
+        if (activePage < pages.size()) {
+            pages[activePage]->content->setVisible(false, false);
+            pages[activePage]->onClose();
+        }
         activePage = i;
         pages[i]->content->setVisible(true, false);
         pages[i]->content->moveToTop();
         Packer::manuallyPackElement(pages[i]->content, contentArea);
+        pages[i]->onOpen();
     }
 }
 

--- a/src/Interfaces/GUI/Elements/Slider.cpp
+++ b/src/Interfaces/GUI/Elements/Slider.cpp
@@ -126,9 +126,11 @@ void Slider::sliderMoved(const Action& drag) {
     if (drag.type != Action::Dragged) return;
 
     const unsigned int size = calculateFreeSize();
-    int dragAmount          = 0;
-    int pos                 = 0;
-    int offset              = 0;
+    if (size == 0) return;
+
+    int dragAmount = 0;
+    int pos        = 0;
+    int offset     = 0;
     if (dir == Horizontal) {
         pos        = slider->getAcquisition().left;
         dragAmount = drag.position.x - drag.data.dragStart.x;

--- a/src/Interfaces/GUI/Elements/ToggleButton.cpp
+++ b/src/Interfaces/GUI/Elements/ToggleButton.cpp
@@ -58,7 +58,7 @@ bool ToggleButton::handleRawEvent(const RawEvent& event) {
 sf::Vector2i ToggleButton::minimumRequisition() const {
     const sf::Vector2i butReq   = activeButton->getRequisition();
     const sf::Vector2i childReq = getChild()->getRequisition();
-    return {butReq.x + childReq.x + 2, std::max(butReq.y, childReq.y)};
+    return {butReq.x + childReq.x + 12, std::max(butReq.y, childReq.y)};
 }
 
 void ToggleButton::onAcquisition() {

--- a/src/Interfaces/GUI/Renderers/DefaultRenderer.cpp
+++ b/src/Interfaces/GUI/Renderers/DefaultRenderer.cpp
@@ -380,7 +380,6 @@ void DefaultRenderer::renderTextEntry(sf::RenderTarget& target, sf::RenderStates
     settings.promoteSecondaries();
     sf::Text text =
         RendererUtil::buildRenderText(entry.getInput(), textArea, settings, textDefaults);
-    text.setPosition(text.getPosition().x, text.getPosition().y - text.getLocalBounds().top);
     target.draw(text, states);
 
     if (entry.cursorVisible()) {

--- a/src/Interfaces/GUI/Renderers/DefaultRenderer.cpp
+++ b/src/Interfaces/GUI/Renderers/DefaultRenderer.cpp
@@ -36,7 +36,7 @@ RenderSettings getTitlebarDefaults() {
 
 RenderSettings getButtonDefaults() {
     RenderSettings settings;
-    settings.fillColor        = sf::Color(70, 70, 70);
+    settings.fillColor        = sf::Color(85, 85, 85);
     settings.outlineColor     = sf::Color::Black;
     settings.outlineThickness = Button::DefaultOutlineThickness;
     return settings;

--- a/src/Interfaces/GUI/Renderers/DefaultRenderer.cpp
+++ b/src/Interfaces/GUI/Renderers/DefaultRenderer.cpp
@@ -171,10 +171,13 @@ void DefaultRenderer::renderComboBox(sf::RenderTarget& target, sf::RenderStates 
     static const RenderSettings defaults = getComboDefaults();
     const RenderSettings settings        = getSettings(&box);
 
-    RendererUtil::renderRectangle(target, states, box.getAcquisition(), settings, defaults);
+    RendererUtil::renderRectangle(target,
+                                  states,
+                                  {0, 0, box.getAcquisition().width, box.getAcquisition().height},
+                                  settings,
+                                  defaults);
 
-    sf::Vector2i pos(box.getAcquisition().left,
-                     box.getAcquisition().top + box.getAcquisition().height);
+    sf::Vector2i pos(0, box.getAcquisition().height);
     for (unsigned int i = 0; i < optionCount; ++i) {
         RenderSettings s = settings;
         if (i == mousedOption) {

--- a/src/Interfaces/GUI/Renderers/DefaultRenderer.cpp
+++ b/src/Interfaces/GUI/Renderers/DefaultRenderer.cpp
@@ -418,7 +418,7 @@ void DefaultRenderer::renderToggleCheckButton(sf::RenderTexture& texture, bool a
 
 void DefaultRenderer::renderToggleRadioButton(sf::RenderTexture& texture, bool active) const {
     const sf::Vector2f size = static_cast<sf::Vector2f>(texture.getSize());
-    const float radius      = std::min(size.x, size.y) * 0.4;
+    const float radius      = std::min(size.x, size.y) * 0.5f;
     sf::CircleShape circle(radius);
     circle.setPosition(size.x / 2, size.y / 2);
     circle.setOrigin(radius, radius);

--- a/src/Interfaces/GUI/Renderers/DefaultRenderer.cpp
+++ b/src/Interfaces/GUI/Renderers/DefaultRenderer.cpp
@@ -233,7 +233,11 @@ void DefaultRenderer::renderNotebook(sf::RenderTarget& target, sf::RenderStates 
     static const RenderSettings defaults = getNotebookDefaults();
     const RenderSettings settings        = getSettings(&nb);
 
-    RendererUtil::renderRectangle(target, states, nb.getAcquisition(), settings, defaults);
+    RendererUtil::renderRectangle(target,
+                                  states,
+                                  {0, 0, nb.getAcquisition().width, nb.getAcquisition().height},
+                                  settings,
+                                  defaults);
     RendererUtil::renderRectangle(target, states, nb.getTabAcquisition(), settings, defaults, true);
     for (unsigned int i = 0; i < nb.getPages().size(); ++i) {
         Notebook::Page* page       = nb.getPages()[i];


### PR DESCRIPTION
- Add callbacks to `Notebook` for page open and close
- Fix `ComboBox` cutoff render bug
- Add padding to `Notebook` page labels
- Properly bound `Slider` values on drag
- Increase size of `RadioButton` dots
- Fix `RadioButton` cutoff acquisition bug