### PR TITLE
Add sounds to menus

### DIFF
--- a/include/BLIB/Interfaces/Menu/Menu.hpp
+++ b/include/BLIB/Interfaces/Menu/Menu.hpp
@@ -4,6 +4,7 @@
 #include <BLIB/Interfaces/Menu/Event.hpp>
 #include <BLIB/Interfaces/Menu/Item.hpp>
 #include <BLIB/Interfaces/Menu/Selector.hpp>
+#include <BLIB/Media/Audio/AudioSystem.hpp>
 #include <BLIB/Util/Hashes.hpp>
 
 #include <list>
@@ -168,6 +169,48 @@ public:
      */
     const Item* getSelectedItem() const;
 
+    /**
+     * @brief Sets the sound that plays when the selector is moved
+     *
+     * @param sound The sound to play
+     */
+    void setMoveSound(audio::AudioSystem::Handle sound);
+
+    /**
+     * @brief Sets the sound to play when the selector cannot move
+     *
+     * @param sound The sound to play
+     */
+    void setMoveFailSound(audio::AudioSystem::Handle sound);
+
+    /**
+     * @brief Sets the sound to play when an item is activated
+     *
+     * @param sound The sound to play
+     */
+    void setSelectSound(audio::AudioSystem::Handle sound);
+
+    /**
+     * @brief Sets the sound that plays when the selector is moved. Applies to all new menus
+     *
+     * @param sound The sound to play
+     */
+    static void setDefaultMoveSound(audio::AudioSystem::Handle sound);
+
+    /**
+     * @brief Sets the sound to play when the selector cannot move. Applies to all new menus
+     *
+     * @param sound The sound to play
+     */
+    static void setDefaultMoveFailSound(audio::AudioSystem::Handle sound);
+
+    /**
+     * @brief Sets the sound that plays when the selector is moved. Applies to all new menus
+     *
+     * @param sound The sound to play
+     */
+    static void setDefaultSelectSound(audio::AudioSystem::Handle sound);
+
 private:
     sf::Vector2f maxSize;
     sf::Vector2f position;
@@ -180,10 +223,18 @@ private:
     sf::RectangleShape background;
     sf::Vector2f totalSize;
     sf::FloatRect bgndPadding;
+    audio::AudioSystem::Handle moveSound;
+    audio::AudioSystem::Handle failSound;
+    audio::AudioSystem::Handle selectSound;
 
     sf::Vector2f move(const sf::Vector2f& pos, const sf::Vector2f& psize, const sf::Vector2f& esize,
                       Item::AttachPoint ap);
     void refreshScroll();
+    void playSound(audio::AudioSystem::Handle sound) const;
+
+    static audio::AudioSystem::Handle defaultMoveSound;
+    static audio::AudioSystem::Handle defaultFailSound;
+    static audio::AudioSystem::Handle defaultSelectSound;
 };
 
 } // namespace menu

--- a/include/BLIB/Media/Audio/AudioSystem.hpp
+++ b/include/BLIB/Media/Audio/AudioSystem.hpp
@@ -49,6 +49,14 @@ public:
     static bool playSound(Handle sound, float fadeIn = -1.f, bool loop = false);
 
     /**
+     * @brief Immediately plays or restarts the given sound, without fade-in and no looping
+     *
+     * @param sound The sound to play or restart
+     * @return True if the sound could be played, false if not found
+     */
+    static bool playOrRestartSound(Handle sound);
+
+    /**
      * @brief Stops the given sound if it is playing
      *
      * @param sound The sound to stop

--- a/src/Resources/GarbageCollector.cpp
+++ b/src/Resources/GarbageCollector.cpp
@@ -52,7 +52,6 @@ GarbageCollector& GarbageCollector::get() {
 void GarbageCollector::registerManager(ManagerBase* m) {
     std::unique_lock lock(managerLock);
     managers.emplace_back(m, m->gcPeriod);
-    BL_LOG_INFO << "registerd manager";
     lock.unlock();
     quitCv.notify_all();
 }
@@ -66,15 +65,12 @@ void GarbageCollector::unregisterManager(ManagerBase* m) {
             break;
         }
     }
-
-    BL_LOG_INFO << "unregistered manager";
 }
 
 void GarbageCollector::runner() {
     while (!quitFlag) {
         std::unique_lock lock(managerLock);
         if (managers.empty()) {
-            BL_LOG_INFO << "waiting for resources to manage";
             quitCv.wait_for(lock, std::chrono::seconds(60));
             continue;
         }
@@ -83,12 +79,10 @@ void GarbageCollector::runner() {
         auto& mp                     = managers[soonestIndex()];
         const unsigned int sleepTime = mp.second;
         const auto startTime         = std::chrono::steady_clock::now();
-        BL_LOG_INFO << "sleeping for: " << sleepTime;
         quitCv.wait_for(lock, std::chrono::seconds(sleepTime));
         const unsigned int sleptTime = std::chrono::duration_cast<std::chrono::seconds>(
                                            std::chrono::steady_clock::now() - startTime)
                                            .count();
-        BL_LOG_INFO << "slept for " << sleptTime;
 
         // check if we need to bail
         if (quitFlag) return;
@@ -99,11 +93,9 @@ void GarbageCollector::runner() {
             if (omp.second <= sleptTime) {
                 omp.first->doClean();
                 omp.second = omp.first->gcPeriod;
-                BL_LOG_INFO << "cleaned oned";
             }
             else {
                 omp.second -= sleptTime;
-                BL_LOG_INFO << "skipped one";
             }
         }
     }


### PR DESCRIPTION
- `AudioSystem` keeps track of source files and reloads expired audio
- Added `playOrRestartSound` to `AudioSystem` to ensure sounds can restart even if not done playing
- Added move, select, move-failed sounds to menus