### PR TITLE
Implement entity relationships in ECS

### DIFF
--- a/include/BLIB/Containers/CMakeLists.txt
+++ b/include/BLIB/Containers/CMakeLists.txt
@@ -2,6 +2,7 @@ target_sources(BLIB PUBLIC
     Vector2d.hpp
     Cache.hpp
     FastQueue.hpp
+    IndexMappedList.hpp
     ObjectWrapper.hpp
     RingBuffer.hpp
     RingQueue.hpp

--- a/include/BLIB/Containers/IndexMappedList.hpp
+++ b/include/BLIB/Containers/IndexMappedList.hpp
@@ -24,8 +24,9 @@ template<typename TKey, typename TValue>
 class IndexMappedList {
     static_assert(std::is_unsigned_v<TKey>, "Key must be a 0-based index");
 
-public:
     struct Item;
+
+public:
     struct Iterator;
     struct Range;
 
@@ -227,6 +228,8 @@ private:
             next = NoNext;
         }
     };
+
+    friend struct Iterator;
 };
 
 //////////////////////////// INLINE FUNCTIONS /////////////////////////////////

--- a/include/BLIB/Containers/IndexMappedList.hpp
+++ b/include/BLIB/Containers/IndexMappedList.hpp
@@ -259,7 +259,7 @@ bool IndexMappedList<TKey, TValue>::hasValue(TKey key, const TValue& value) cons
 }
 
 template<typename TKey, typename TValue>
-IndexMappedList<TKey, TValue>::Range IndexMappedList<TKey, TValue>::getValues(TKey key) {
+typename IndexMappedList<TKey, TValue>::Range IndexMappedList<TKey, TValue>::getValues(TKey key) {
     return {hasValues(key) ? Iterator(&storage, keyToStartIndex[key]) : Iterator()};
 }
 

--- a/include/BLIB/Containers/IndexMappedList.hpp
+++ b/include/BLIB/Containers/IndexMappedList.hpp
@@ -1,0 +1,340 @@
+#ifndef BLIB_CONTAINERS_INDEXMAPPEDLIST_HPP
+#define BLIB_CONTAINERS_INDEXMAPPEDLIST_HPP
+
+#include <BLIB/Util/IdAllocatorUnbounded.hpp>
+#include <limits>
+#include <optional>
+#include <type_traits>
+#include <vector>
+
+namespace bl
+{
+namespace ctr
+{
+/**
+ * @brief Specialized storage that is like a multimap, but internally is comprised of only a few
+ *        vectors. This keeps the storage relatively cache friendly and helps to minimize
+ *        fragmentation over time. Chief usage is one-to-many relationship mapping in the ECS
+ *
+ * @tparam TKey The key type. Must be an unsigned integer
+ * @tparam TValue The value type
+ * @ingroup Containers
+ */
+template<typename TKey, typename TValue>
+class IndexMappedList {
+    static_assert(std::is_unsigned_v<TKey>, "Key must be a 0-based index");
+
+public:
+    struct Item;
+    struct Iterator;
+    struct Range;
+
+    /**
+     * @brief Creates a new index mapped list with the given capacity hint
+     *
+     * @param capacityHint The amount of capacity to reserve
+     */
+    IndexMappedList(std::size_t capacityHint = 64);
+
+    /**
+     * @brief Returns whether or not the given key has any values
+     *
+     * @param key The key to test
+     * @return True if the key has values, false otherwise
+     */
+    bool hasValues(TKey key) const;
+
+    /**
+     * @brief Returns if the given key contains the given value
+     *
+     * @param key The key to check the values of
+     * @param value The specific value to search for
+     * @return True if the key has the value, false otherwise
+     */
+    bool hasValue(TKey key, const TValue& value) const;
+
+    /**
+     * @brief Returns the range of values for a given key. May be empty
+     *
+     * @param key The key to get the values for
+     * @return Iterable range of values for the given key
+     */
+    Range getValues(TKey key);
+
+    /**
+     * @brief Removes the specific value for the given key. Safe if the value is not contained
+     *
+     * @param key The key to remove the value for
+     * @param value The value to remove
+     */
+    void removeValue(TKey key, const TValue& value);
+
+    /**
+     * @brief Removes all values for the given key
+     *
+     * @param key The key to clear from the map
+     */
+    void remove(TKey key);
+
+    /**
+     * @brief Adds the value to the given key
+     *
+     * @param key The key to add the value for
+     * @param value The value to add
+     */
+    void add(TKey key, TValue value);
+
+    /**
+     * @brief Clears all values and keys
+     */
+    void clear();
+
+    /**
+     * @brief Iterator over values for a specific key
+     */
+    struct Iterator {
+        /**
+         * @brief Returns whether or not the iterator may be advanced or dereferenced
+         */
+        bool isValid() const { return current != nullptr; }
+
+        /**
+         * @brief Returns whether or not the iterator is the last value in the sequence
+         */
+        bool hasNext() const { return isValid() && current->next != NoNext; }
+
+        /**
+         * @brief Returns an iterator to the next element, leaving this one unchanged
+         */
+        Iterator next() const {
+            Iterator n = *this;
+            n.advance();
+            return n;
+        }
+
+        /**
+         * @brief Advances this iterator to the next element
+         */
+        void advance() { current = hasNext() ? &(*storage)[current->next] : nullptr; }
+
+        /**
+         * @brief Advances this iterator to the next element
+         */
+        Iterator& operator++() {
+            advance();
+            return *this;
+        }
+
+        /**
+         * @brief Advances this iterator to the next element and returns the prior value
+         */
+        Iterator operator++(int) {
+            Iterator prev = *this;
+            advance();
+            return prev;
+        }
+
+        /**
+         * @brief Access the value the iterator points to
+         */
+        TValue& operator*() { return current->payload.value(); }
+
+        /**
+         * @brief Access the value the iterator points to
+         */
+        const TValue& operator*() const { return current->payload.value(); }
+
+        /**
+         * @brief Access the value the iterator points to
+         */
+        TValue* operator->() { return &current->payload.value(); }
+
+        /**
+         * @brief Access the value the iterator points to
+         */
+        const TValue* operator->() const { return &current->payload.value(); }
+
+        /**
+         * @brief Returns whether or not the given iterator is the same as this one
+         */
+        bool operator==(const Iterator& right) const { return current == right.current; }
+
+        /**
+         * @brief Returns whether or not the given iterator is different than this one
+         */
+        bool operator!=(const Iterator& right) const { return current != right.current; }
+
+    private:
+        std::vector<Item>* storage;
+        Item* current;
+
+        Iterator()
+        : storage(nullptr)
+        , current(nullptr) {}
+
+        Iterator(std::vector<Item>* storage, std::uint32_t i)
+        : storage(storage)
+        , current(&(*storage)[i]) {}
+
+        friend struct Range;
+        friend class IndexMappedList;
+    };
+
+    /**
+     * @brief Helper struct to allow range-based for loops
+     */
+    struct Range {
+        /**
+         * @brief The beginning of the sequence
+         */
+        Iterator begin() const { return start; }
+
+        /**
+         * @brief Returns an invalid sentinel value
+         */
+        Iterator end() const { return Iterator(); }
+
+    private:
+        Range() = default;
+        Range(Iterator start)
+        : start(start) {}
+
+        Iterator start;
+
+        friend class IndexMappedList;
+    };
+
+private:
+    static constexpr std::uint32_t NoNext = std::numeric_limits<std::uint32_t>::max();
+
+    std::vector<Item> storage;
+    util::IdAllocatorUnbounded<std::uint32_t> freeSet;
+    std::vector<std::uint32_t> keyToStartIndex;
+
+    void ensureValueCapacity(std::uint32_t cap);
+    void ensureKeyCapacity(std::uint32_t cap);
+    void reset(std::uint32_t i);
+
+    struct Item {
+        std::optional<TValue> payload;
+        std::uint32_t next;
+
+        Item()
+        : next(NoNext) {}
+
+        void clear() {
+            payload.reset();
+            next = NoNext;
+        }
+    };
+};
+
+//////////////////////////// INLINE FUNCTIONS /////////////////////////////////
+
+template<typename TKey, typename TValue>
+IndexMappedList<TKey, TValue>::IndexMappedList(std::size_t capacityHint)
+: freeSet(capacityHint) {
+    ensureKeyCapacity(capacityHint);
+    ensureValueCapacity(capacityHint);
+}
+
+template<typename TKey, typename TValue>
+bool IndexMappedList<TKey, TValue>::hasValues(TKey key) const {
+    return key < keyToStartIndex.size() && keyToStartIndex[key] != NoNext;
+}
+
+template<typename TKey, typename TValue>
+bool IndexMappedList<TKey, TValue>::hasValue(TKey key, const TValue& value) const {
+    if (key >= keyToStartIndex.size()) { return false; }
+
+    std::uint32_t i = keyToStartIndex[key];
+    while (i < storage.size()) {
+        if (storage[i].payload.value() == value) { return true; }
+        i = storage[i].next;
+    }
+    return false;
+}
+
+template<typename TKey, typename TValue>
+IndexMappedList<TKey, TValue>::Range IndexMappedList<TKey, TValue>::getValues(TKey key) {
+    return {hasValues(key) ? Iterator(&storage, keyToStartIndex[key]) : Iterator()};
+}
+
+template<typename TKey, typename TValue>
+void IndexMappedList<TKey, TValue>::removeValue(TKey key, const TValue& value) {
+    if (key >= keyToStartIndex.size()) { return; }
+
+    std::uint32_t i = keyToStartIndex[key];
+    if (i != NoNext) {
+        if (storage[i].payload.value() == value) {
+            keyToStartIndex[key] = storage[i].next;
+            reset(i);
+        }
+        else if (storage[i].next != NoNext) {
+            do {
+                std::uint32_t prev = i;
+                i                  = storage[i].next;
+                if (storage[i].payload.value() == value) {
+                    storage[prev].next = storage[i].next;
+                    reset(i);
+                    break;
+                }
+            } while (storage[i].next != NoNext);
+        }
+    }
+}
+
+template<typename TKey, typename TValue>
+void IndexMappedList<TKey, TValue>::remove(TKey key) {
+    if (key >= keyToStartIndex.size()) { return; }
+
+    std::uint32_t i = keyToStartIndex[key];
+    if (i != NoNext) {
+        keyToStartIndex[key] = NoNext;
+        do {
+            const std::uint32_t n = storage[i].next;
+            reset(i);
+            i = n;
+        } while (i != NoNext);
+    }
+}
+
+template<typename TKey, typename TValue>
+void IndexMappedList<TKey, TValue>::add(TKey key, TValue value) {
+    const std::uint32_t i = freeSet.allocate();
+    ensureKeyCapacity(key + 1);
+    ensureValueCapacity(i + 1);
+    storage[i].payload.emplace(std::forward<TValue>(value));
+
+    std::uint32_t& startIndex = keyToStartIndex[key];
+    storage[i].next           = startIndex;
+    startIndex                = i;
+}
+
+template<typename TKey, typename TValue>
+void IndexMappedList<TKey, TValue>::clear() {
+    std::fill(keyToStartIndex.begin(), keyToStartIndex.end(), NoNext);
+    for (Item& item : storage) { item.clear(); }
+    freeSet.releaseAll();
+}
+
+template<typename TKey, typename TValue>
+inline void IndexMappedList<TKey, TValue>::ensureValueCapacity(std::uint32_t cap) {
+    if (storage.size() < cap) { storage.resize(cap); }
+}
+
+template<typename TKey, typename TValue>
+inline void IndexMappedList<TKey, TValue>::ensureKeyCapacity(std::uint32_t cap) {
+    if (keyToStartIndex.size() < cap) { keyToStartIndex.resize(cap, NoNext); }
+}
+
+template<typename TKey, typename TValue>
+inline void IndexMappedList<TKey, TValue>::reset(std::uint32_t i) {
+    storage[i].clear();
+    freeSet.release(i);
+}
+
+} // namespace ctr
+} // namespace bl
+
+#endif

--- a/include/BLIB/ECS/CMakeLists.txt
+++ b/include/BLIB/ECS/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(BLIB PUBLIC
     ComponentPool.hpp
     ComponentSet.hpp
     ComponentSetImpl.hpp
+    DependencyGraph.hpp
     Entity.hpp
     Events.hpp
     ParentGraph.hpp

--- a/include/BLIB/ECS/CMakeLists.txt
+++ b/include/BLIB/ECS/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(BLIB PUBLIC
     ComponentSetImpl.hpp
     Entity.hpp
     Events.hpp
+    ParentGraph.hpp
     Registry.hpp
     StableHandle.hpp
     Tags.hpp

--- a/include/BLIB/ECS/CMakeLists.txt
+++ b/include/BLIB/ECS/CMakeLists.txt
@@ -14,3 +14,5 @@ target_sources(BLIB PUBLIC
     View.hpp
     ViewImpl.hpp
 )
+
+add_subdirectory(Traits)

--- a/include/BLIB/ECS/ComponentPool.hpp
+++ b/include/BLIB/ECS/ComponentPool.hpp
@@ -50,6 +50,9 @@ protected:
     virtual void remove(Entity entity) = 0;
     virtual void clear()               = 0;
 
+    virtual void onParentSet(Entity child, Entity parent) = 0;
+    virtual void onParentRemove(Entity orphan)            = 0;
+
     template<typename TRequire, typename TOptional, typename TExclude>
     friend class View;
     friend class Registry;
@@ -112,6 +115,9 @@ private:
 
     virtual void remove(Entity entity) override;
     virtual void clear() override;
+
+    virtual void onParentSet(Entity child, Entity parent) override;
+    virtual void onParentRemove(Entity orphan) override;
 
     friend class Registry;
 };
@@ -220,6 +226,16 @@ void ComponentPool<T>::clear() {
     std::fill(indexToEntity.begin(), indexToEntity.end(), InvalidEntity);
     std::fill(entityToIndex.begin(), entityToIndex.end(), InvalidIndex);
     indexAllocator.releaseAll();
+}
+
+template<typename T>
+void ComponentPool<T>::onParentSet(Entity child, Entity parent) {
+    // TODO - specialize with enable_if and call into specialized component
+}
+
+template<typename T>
+void ComponentPool<T>::onParentRemove(Entity orphan) {
+    // TODO - specialize with enable_if and call into specialized component
 }
 
 template<typename T>

--- a/include/BLIB/ECS/DependencyGraph.hpp
+++ b/include/BLIB/ECS/DependencyGraph.hpp
@@ -8,19 +8,56 @@ namespace bl
 {
 namespace ecs
 {
+/**
+ * @brief Helper to store and manage dependencies between components
+ *
+ * @ingroup ECS
+ */
 class DependencyGraph {
 public:
+    /**
+     * @brief Creates the graph with the given capacity hint
+     *
+     * @param capacityHint The number of expected entities
+     */
     DependencyGraph(std::size_t capacityHint);
 
+    /**
+     * @brief Adds a dependency between two entities
+     *
+     * @param parent The entity being depended on
+     * @param child The entity depending on
+     */
     void addDependency(Entity parent, Entity child);
 
+    /**
+     * @brief Returns whether or not the given entity has others depending on it
+     *
+     * @param parent The entity to check
+     * @return True if dependencies are present, false otherwise
+     */
     bool hasDependencies(Entity parent) const;
 
+    /**
+     * @brief Removes the given dependency
+     *
+     * @param parent The entity being depended on
+     * @param child The entity depending on
+     */
     void removeDependency(Entity parent, Entity child);
 
-    void removeEntity(Entity child);
-
+    /**
+     * @brief Clears out all relationship data
+     */
     void clear();
+
+    /**
+     * @brief Returns an iterable of dependencies for the given entity
+     *
+     * @param child The entity to get dependencies for
+     * @return An iterable of entities that are depended on
+     */
+    ctr::IndexMappedList<std::uint32_t, Entity>::Range getResources(Entity child);
 
 private:
     ctr::IndexMappedList<std::uint32_t, Entity> parentsToChildren;

--- a/include/BLIB/ECS/DependencyGraph.hpp
+++ b/include/BLIB/ECS/DependencyGraph.hpp
@@ -1,0 +1,33 @@
+#ifndef BLIB_ECS_DEPENDENCYGRAPH_HPP
+#define BLIB_ECS_DEPENDENCYGRAPH_HPP
+
+#include <BLIB/Containers/IndexMappedList.hpp>
+#include <BLIB/ECS/Entity.hpp>
+
+namespace bl
+{
+namespace ecs
+{
+class DependencyGraph {
+public:
+    DependencyGraph(std::size_t capacityHint);
+
+    void addDependency(Entity parent, Entity child);
+
+    bool hasDependencies(Entity parent) const;
+
+    void removeDependency(Entity parent, Entity child);
+
+    void removeEntity(Entity child);
+
+    void clear();
+
+private:
+    ctr::IndexMappedList<std::uint32_t, Entity> parentsToChildren;
+    ctr::IndexMappedList<std::uint32_t, Entity> childrenToParents;
+};
+
+} // namespace ecs
+} // namespace bl
+
+#endif

--- a/include/BLIB/ECS/Entity.hpp
+++ b/include/BLIB/ECS/Entity.hpp
@@ -18,7 +18,7 @@ namespace ecs
  * @ingroup Entity
  *
  */
-using Entity = std::uint32_t;
+using Entity = std::uint64_t;
 
 /**
  * @brief Special value to indicate that an Entity is not valid
@@ -27,6 +27,44 @@ using Entity = std::uint32_t;
  *
  */
 constexpr Entity InvalidEntity = std::numeric_limits<Entity>::max();
+
+/**
+ * @brief Helpers for extracting entity metadata from entity ids
+ *
+ * @ingroup ECS
+ */
+struct IdUtil {
+    static constexpr std::uint64_t IndexMask   = 0x00000000FFFFFFFF;
+    static constexpr std::uint64_t VersionMask = 0xFFFF000000000000;
+
+    /**
+     * @brief Returns the 0-based index for the given entity
+     *
+     * @param entity The entity to get the index for
+     * @return The 0-based index of the entity
+     */
+    static std::uint64_t getEntityIndex(Entity entity) { return entity & IndexMask; }
+
+    /**
+     * @brief Returns the version of an entity. The same entity index may be reused, the version
+     *        differentiates it from the prior instances
+     *
+     * @param entity The entity to get the version for
+     * @return The version number of the entity
+     */
+    static std::uint64_t getEntityVersion(Entity entity) { return (entity & VersionMask) >> 48; }
+
+    /**
+     * @brief Creates an entity id from the given index and version
+     * 
+     * @param index The index of the entity
+     * @param version The version of the entity
+     * @return The combined entity id
+    */
+    static Entity composeEntity(std::uint64_t index, std::uint64_t version) {
+        return (version << 48) | index;
+    }
+};
 
 } // namespace ecs
 

--- a/include/BLIB/ECS/Entity.hpp
+++ b/include/BLIB/ECS/Entity.hpp
@@ -26,7 +26,7 @@ using Entity = std::uint64_t;
  * @ingroup ECS
  *
  */
-constexpr Entity InvalidEntity = std::numeric_limits<Entity>::max();
+constexpr Entity InvalidEntity = 0;
 
 /**
  * @brief Helpers for extracting entity metadata from entity ids

--- a/include/BLIB/ECS/ParentGraph.hpp
+++ b/include/BLIB/ECS/ParentGraph.hpp
@@ -1,0 +1,67 @@
+#ifndef BLIB_ECS_PARENTGRAPH_HPP
+#define BLIB_ECS_PARENTGRAPH_HPP
+
+#include <BLIB/Containers/IndexMappedList.hpp>
+#include <BLIB/ECS/Entity.hpp>
+
+namespace bl
+{
+namespace ecs
+{
+/**
+ * @brief Utility class to store and manage child <-> parent entity relationships in the ECS
+ * 
+ * @ingroup ECS
+*/
+class ParentGraph {
+public:
+    /**
+     * @brief Creates an empty graph
+     * 
+     * @param capacityHint The expected number of entities to manage
+    */
+    ParentGraph(std::size_t capacityHint);
+
+    /**
+     * @brief Adds a parent <-> child association
+     * 
+     * @param child The child entity id
+     * @param parent The parent entity id
+    */
+    void setParent(Entity child, Entity parent);
+
+    /**
+     * @brief Removes the parent from the given entity
+     * 
+     * @param child The child to orphan
+    */
+    void unParent(Entity child);
+
+    /**
+     * @brief Returns the parent for the given child
+     * 
+     * @param child The child entity to get the parent of
+     * @return The parent entity id, or InvalidEntity
+    */
+    Entity getParent(Entity child);
+
+    /**
+     * @brief Returns a range of children for the given entity
+     * 
+     * @param parent The parent to get the children of
+     * @return The range of children. May be empty
+    */
+    ctr::IndexMappedList<std::uint32_t, Entity>::Range getChildren(Entity parent);
+
+private:
+    std::vector<Entity> parentMap;
+    ctr::IndexMappedList<std::uint32_t, Entity> childMap;
+
+    void ensureParentCap(Entity child);
+    bool checkForCycles(Entity start);
+};
+
+} // namespace ecs
+} // namespace bl
+
+#endif

--- a/include/BLIB/ECS/ParentGraph.hpp
+++ b/include/BLIB/ECS/ParentGraph.hpp
@@ -10,48 +10,61 @@ namespace ecs
 {
 /**
  * @brief Utility class to store and manage child <-> parent entity relationships in the ECS
- * 
+ *
  * @ingroup ECS
-*/
+ */
 class ParentGraph {
 public:
     /**
      * @brief Creates an empty graph
-     * 
+     *
      * @param capacityHint The expected number of entities to manage
-    */
+     */
     ParentGraph(std::size_t capacityHint);
 
     /**
      * @brief Adds a parent <-> child association
-     * 
+     *
      * @param child The child entity id
      * @param parent The parent entity id
-    */
+     */
     void setParent(Entity child, Entity parent);
 
     /**
      * @brief Removes the parent from the given entity
-     * 
+     *
      * @param child The child to orphan
-    */
+     */
     void unParent(Entity child);
 
     /**
      * @brief Returns the parent for the given child
-     * 
+     *
      * @param child The child entity to get the parent of
      * @return The parent entity id, or InvalidEntity
-    */
+     */
     Entity getParent(Entity child);
 
     /**
      * @brief Returns a range of children for the given entity
-     * 
+     *
      * @param parent The parent to get the children of
      * @return The range of children. May be empty
-    */
+     */
     ctr::IndexMappedList<std::uint32_t, Entity>::Range getChildren(Entity parent);
+
+    /**
+     * @brief Resets the entire graph to the empty state
+     */
+    void reset();
+
+    /**
+     * @brief Removes the given entity from the graph. Does not update children. remove() must be
+     *        called manually for all children
+     *
+     * @param entity The entity to remove
+     */
+    void removeEntity(Entity entity);
 
 private:
     std::vector<Entity> parentMap;

--- a/include/BLIB/ECS/Traits/CMakeLists.txt
+++ b/include/BLIB/ECS/Traits/CMakeLists.txt
@@ -1,0 +1,3 @@
+target_sources(BLIB PUBLIC
+    ParentAware.hpp
+)

--- a/include/BLIB/ECS/Traits/ParentAware.hpp
+++ b/include/BLIB/ECS/Traits/ParentAware.hpp
@@ -1,0 +1,78 @@
+#ifndef BLIB_ECS_PARENTAWARE_HPP
+#define BLIB_ECS_PARENTAWARE_HPP
+
+#include <type_traits>
+
+namespace bl
+{
+namespace ecs
+{
+template<typename T>
+class ComponentPool;
+
+namespace trait
+{
+
+/**
+ * @brief Component trait for components that are parent-able. Parent is set in the Registry as an
+ *        entity-level relationship. Components should inherit this trait and pass their own type
+ *        as the type parameter T
+ *
+ * @tparam T The component type
+ * @ingroup ECS
+ */
+template<typename T>
+class ParentAware {
+public:
+    /**
+     * @brief Sets the parent to nullptr
+     */
+    ParentAware();
+
+    /**
+     * @brief Returns whether or not a parent has been set
+     */
+    bool hasParent() const;
+
+    /**
+     * @brief Returns the parent component
+     */
+    T& getParent();
+
+    /**
+     * @brief Returns the parent component
+     */
+    const T& getParent() const;
+
+private:
+    T* parent;
+
+    friend class ComponentPool<T>;
+};
+
+//////////////////////////// INLINE FUNCTIONS /////////////////////////////////
+
+template<typename T>
+ParentAware<T>::ParentAware()
+: parent(nullptr) {}
+
+template<typename T>
+bool ParentAware<T>::hasParent() const {
+    return parent != nullptr;
+}
+
+template<typename T>
+T& ParentAware<T>::getParent() {
+    return *parent;
+}
+
+template<typename T>
+const T& ParentAware<T>::getParent() const {
+    return *parent;
+}
+
+} // namespace trait
+} // namespace ecs
+} // namespace bl
+
+#endif

--- a/include/BLIB/ECS/ViewImpl.hpp
+++ b/include/BLIB/ECS/ViewImpl.hpp
@@ -110,27 +110,32 @@ private:
         }
 
         for (Entity ent : toAdd) {
-            if (ent + 1 >= entityToIndex.size()) { entityToIndex.resize(ent + 1, InvalidIndex); }
+            const std::uint64_t entIndex = IdUtil::getEntityIndex(ent);
+            if (entIndex + 1 > entityToIndex.size()) {
+                entityToIndex.resize(entIndex + 1, InvalidIndex);
+            }
 
-            if (entityToIndex[ent] != InvalidIndex) { continue; }
-            if (!mask.passes(registry.entityMasks[ent])) { continue; }
+            if (entityToIndex[entIndex] != InvalidIndex) { continue; }
+            if (!mask.passes(registry.entityMasks[entIndex])) { continue; }
 
             const std::size_t ni = results.size();
             results.emplace_back(registry, ent);
             if (!results.back().isValid()) { results.pop_back(); }
-            else { entityToIndex[ent] = ni; }
+            else { entityToIndex[entIndex] = ni; }
         }
         toAdd.clear();
 
         for (Entity ent : toRemove) {
-            if (ent + 1 >= entityToIndex.size()) { continue; }
+            const std::uint64_t entIndex = IdUtil::getEntityIndex(ent);
+            if (entIndex + 1 > entityToIndex.size()) { continue; }
 
-            std::size_t& index = entityToIndex[ent];
+            std::size_t& index = entityToIndex[entIndex];
             if (index == InvalidIndex) { continue; }
             if (index != results.size() - 1) {
-                std::size_t& backIndex = entityToIndex[results.back().entity()];
-                results[index]         = results.back();
-                backIndex              = index;
+                std::size_t& backIndex =
+                    entityToIndex[IdUtil::getEntityIndex(results.back().entity())];
+                results[index] = results.back();
+                backIndex      = index;
             }
             results.pop_back();
             index = InvalidIndex;

--- a/include/BLIB/Render/Descriptors/DescriptorComponentStorage.hpp
+++ b/include/BLIB/Render/Descriptors/DescriptorComponentStorage.hpp
@@ -218,7 +218,7 @@ void DescriptorComponentStorage<TCom, TPayload, TDynamicStorage, TStaticStorage>
         const ecs::Entity entity = getEntityFromSceneKey(key);
         if (entity != ecs::InvalidEntity) {
             TCom* component = registry.getComponent<TCom>(entity);
-            if (component) { component->link(this, {speed, ecs::InvalidEntity}, payload); }
+            if (component) { component->link(this, {speed, scene::Key::InvalidSceneId}, payload); }
         }
     }
 }

--- a/include/BLIB/Render/Scenes/Key.hpp
+++ b/include/BLIB/Render/Scenes/Key.hpp
@@ -20,6 +20,8 @@ namespace scene
  * @ingroup Renderer
  */
 struct Key {
+    static constexpr std::uint32_t InvalidSceneId = std::numeric_limits<std::uint32_t>::max();
+
     UpdateSpeed updateFreq;
     std::uint32_t sceneId;
 
@@ -28,7 +30,7 @@ struct Key {
      */
     Key()
     : updateFreq(UpdateSpeed::Dynamic)
-    , sceneId(std::numeric_limits<std::uint32_t>::max()) {}
+    , sceneId(InvalidSceneId) {}
 
     /**
      * @brief Creates the key from the given components

--- a/src/ECS/CMakeLists.txt
+++ b/src/ECS/CMakeLists.txt
@@ -1,3 +1,4 @@
 target_sources(BLIB PRIVATE
+    ParentGraph.cpp
     Registry.cpp
 )

--- a/src/ECS/CMakeLists.txt
+++ b/src/ECS/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(BLIB PRIVATE
+    DependencyGraph.cpp
     ParentGraph.cpp
     Registry.cpp
 )

--- a/src/ECS/DependencyGraph.cpp
+++ b/src/ECS/DependencyGraph.cpp
@@ -1,0 +1,40 @@
+#include <BLIB/ECS/DependencyGraph.hpp>
+
+namespace bl
+{
+namespace ecs
+{
+ecs::DependencyGraph::DependencyGraph(std::size_t capacityHint)
+: parentsToChildren(capacityHint)
+, childrenToParents(capacityHint) {}
+
+void DependencyGraph::addDependency(Entity parent, Entity child) {
+    parentsToChildren.add(IdUtil::getEntityIndex(parent), child);
+    childrenToParents.add(IdUtil::getEntityIndex(child), parent);
+}
+
+bool DependencyGraph::hasDependencies(Entity parent) const {
+    return parentsToChildren.hasValues(IdUtil::getEntityIndex(parent));
+}
+
+void DependencyGraph::removeDependency(Entity parent, Entity child) {
+    parentsToChildren.removeValue(IdUtil::getEntityIndex(parent), child);
+    childrenToParents.removeValue(IdUtil::getEntityIndex(child), parent);
+}
+
+void DependencyGraph::removeEntity(Entity child) {
+    const std::uint32_t index = IdUtil::getEntityIndex(child);
+    for (Entity parent : childrenToParents.getValues(child)) {
+        parentsToChildren.removeValue(IdUtil::getEntityIndex(parent), child);
+    }
+    childrenToParents.remove(index);
+    parentsToChildren.remove(index);
+}
+
+void DependencyGraph::clear() {
+    parentsToChildren.clear();
+    childrenToParents.clear();
+}
+
+} // namespace ecs
+} // namespace bl

--- a/src/ECS/DependencyGraph.cpp
+++ b/src/ECS/DependencyGraph.cpp
@@ -22,18 +22,13 @@ void DependencyGraph::removeDependency(Entity parent, Entity child) {
     childrenToParents.removeValue(IdUtil::getEntityIndex(child), parent);
 }
 
-void DependencyGraph::removeEntity(Entity child) {
-    const std::uint32_t index = IdUtil::getEntityIndex(child);
-    for (Entity parent : childrenToParents.getValues(child)) {
-        parentsToChildren.removeValue(IdUtil::getEntityIndex(parent), child);
-    }
-    childrenToParents.remove(index);
-    parentsToChildren.remove(index);
-}
-
 void DependencyGraph::clear() {
     parentsToChildren.clear();
     childrenToParents.clear();
+}
+
+ctr::IndexMappedList<std::uint32_t, Entity>::Range DependencyGraph::getResources(Entity child) {
+    return childrenToParents.getValues(IdUtil::getEntityIndex(child));
 }
 
 } // namespace ecs

--- a/src/ECS/ParentGraph.cpp
+++ b/src/ECS/ParentGraph.cpp
@@ -1,0 +1,80 @@
+#include <BLIB/ECS/ParentGraph.hpp>
+
+#include <BLIB/Logging.hpp>
+
+namespace bl
+{
+namespace ecs
+{
+ecs::ParentGraph::ParentGraph(std::size_t capacityHint)
+: parentMap(capacityHint, InvalidEntity)
+, childMap(capacityHint) {}
+
+void ParentGraph::setParent(Entity child, Entity parent) {
+    ensureParentCap(child);
+
+    const std::size_t i   = IdUtil::getEntityIndex(child);
+    const Entity ogParent = parentMap[i];
+    if (ogParent == parent) { return; }
+    else if (ogParent != InvalidEntity) { unParent(child); }
+
+    parentMap[i] = parent;
+    childMap.add(IdUtil::getEntityIndex(parent), child);
+
+#ifdef BLIB_DEBUG
+    if (checkForCycles(child)) {
+        BL_LOG_CRITICAL << "Cycle created when assigning parent " << parent << " to entity "
+                        << child;
+        std::abort();
+    }
+#endif
+}
+
+void ParentGraph::unParent(Entity child) {
+    const std::size_t i = IdUtil::getEntityIndex(child);
+    if (parentMap.size() <= i) { return; }
+    if (parentMap[i] == InvalidEntity) { return; }
+
+    const std::uint32_t j = IdUtil::getEntityIndex(parentMap[i]);
+    parentMap[i]          = InvalidEntity;
+    childMap.removeValue(j, child);
+}
+
+Entity ParentGraph::getParent(Entity child) {
+    const std::size_t i = IdUtil::getEntityIndex(child);
+    return i < parentMap.size() ? parentMap[i] : InvalidEntity;
+}
+
+ctr::IndexMappedList<std::uint32_t, Entity>::Range ParentGraph::getChildren(Entity parent) {
+    return childMap.getValues(IdUtil::getEntityIndex(parent));
+}
+
+void ParentGraph::ensureParentCap(Entity child) {
+    const std::size_t cap = IdUtil::getEntityIndex(child) + 1;
+    if (cap > parentMap.size()) { parentMap.resize(cap, InvalidEntity); }
+}
+
+bool ParentGraph::checkForCycles(Entity start) {
+    std::vector<bool> visited(parentMap.size(), false);
+    std::vector<Entity> toVisit;
+    toVisit.reserve(32);
+    toVisit.emplace_back(start);
+
+    while (!toVisit.empty()) {
+        const Entity ent = toVisit.back();
+        toVisit.pop_back();
+        const std::uint32_t i = IdUtil::getEntityIndex(ent);
+
+        if (i >= visited.size()) { visited.resize(i + 1, false); }
+        if (visited[i]) { return true; }
+        visited[i] = true;
+
+        const Entity parent = getParent(ent);
+        if (parent != InvalidEntity) { toVisit.emplace_back(parent); }
+    }
+
+    return false;
+}
+
+} // namespace ecs
+} // namespace bl

--- a/src/ECS/ParentGraph.cpp
+++ b/src/ECS/ParentGraph.cpp
@@ -49,6 +49,21 @@ ctr::IndexMappedList<std::uint32_t, Entity>::Range ParentGraph::getChildren(Enti
     return childMap.getValues(IdUtil::getEntityIndex(parent));
 }
 
+void ParentGraph::reset() {
+    std::fill(parentMap.begin(), parentMap.end(), InvalidEntity);
+    childMap.clear();
+}
+
+void ParentGraph::removeEntity(Entity entity) {
+    const std::size_t i = IdUtil::getEntityIndex(entity);
+    if (i >= parentMap.size()) { return; }
+
+    const Entity parent = parentMap[i];
+    parentMap[i]        = InvalidEntity;
+    childMap.remove(entity);
+    if (parent != InvalidEntity) { childMap.removeValue(IdUtil::getEntityIndex(parent), entity); }
+}
+
 void ParentGraph::ensureParentCap(Entity child) {
     const std::size_t cap = IdUtil::getEntityIndex(child) + 1;
     if (cap > parentMap.size()) { parentMap.resize(cap, InvalidEntity); }

--- a/src/ECS/Registry.cpp
+++ b/src/ECS/Registry.cpp
@@ -6,7 +6,8 @@ namespace ecs
 {
 Registry::Registry()
 : entityAllocator(DefaultCapacity)
-, entityMasks(DefaultCapacity, ComponentMask::EmptyMask) {
+, entityMasks(DefaultCapacity, ComponentMask::EmptyMask)
+, entityVersions(DefaultCapacity, 0) {
     componentPools.reserve(ComponentMask::MaxComponentTypeCount);
     views.reserve(32);
     bl::event::Dispatcher::subscribe(this);
@@ -15,18 +16,32 @@ Registry::Registry()
 Entity Registry::createEntity() {
     std::lock_guard lock(entityLock);
 
-    const Entity ent = entityAllocator.allocate();
-    if (ent + 1 >= entityMasks.size()) { entityMasks.resize(ent + 1, ComponentMask::EmptyMask); }
-    entityMasks[ent] = ComponentMask::EmptyMask;
+    const std::uint64_t index = entityAllocator.allocate();
+    std::uint64_t version     = 1;
+    if (index + 1 > entityMasks.size()) {
+        entityMasks.resize(index + 1, ComponentMask::EmptyMask);
+        entityVersions.resize(index + 1, 1);
+    }
+    else {
+        entityMasks[index] = ComponentMask::EmptyMask;
+        version            = ++entityVersions[index];
+    }
+
+    const Entity ent = IdUtil::composeEntity(index, version);
     bl::event::Dispatcher::dispatch<event::EntityCreated>({ent});
     return ent;
 }
 
-bool Registry::entityExists(Entity ent) const { return entityAllocator.isAllocated(ent); }
+bool Registry::entityExists(Entity ent) const {
+    const std::uint64_t index = IdUtil::getEntityIndex(ent);
+    return entityAllocator.isAllocated(index) &&
+           entityVersions[index] == IdUtil::getEntityVersion(ent);
+}
 
 void Registry::destroyEntity(Entity ent) {
     std::lock_guard lock(entityLock);
-    const ComponentMask::SimpleMask mask = entityMasks[ent];
+    const std::uint32_t index            = IdUtil::getEntityIndex(ent);
+    const ComponentMask::SimpleMask mask = entityMasks[index];
 
     bl::event::Dispatcher::dispatch<event::EntityDestroyed>({ent});
     for (auto& view : views) {
@@ -37,17 +52,18 @@ void Registry::destroyEntity(Entity ent) {
         if (ComponentMask::has(mask, pool->ComponentIndex)) { pool->remove(ent); }
     }
 
-    entityAllocator.release(ent);
-    entityMasks[ent] = ComponentMask::EmptyMask;
+    entityAllocator.release(index);
+    entityMasks[index] = ComponentMask::EmptyMask;
 }
 
 void Registry::destroyAllEntities() {
     std::lock_guard lock(entityLock);
 
     // send entity events
-    for (Entity ent = 0; ent < entityAllocator.poolSize(); ++ent) {
-        if (entityAllocator.isAllocated(ent)) {
-            bl::event::Dispatcher::dispatch<event::EntityDestroyed>({ent});
+    for (std::uint32_t index = 0; index < entityAllocator.poolSize(); ++index) {
+        if (entityAllocator.isAllocated(index)) {
+            bl::event::Dispatcher::dispatch<event::EntityDestroyed>(
+                {IdUtil::composeEntity(index, entityVersions[index])});
         }
     }
 

--- a/src/ECS/Registry.cpp
+++ b/src/ECS/Registry.cpp
@@ -7,7 +7,8 @@ namespace ecs
 Registry::Registry()
 : entityAllocator(DefaultCapacity)
 , entityMasks(DefaultCapacity, ComponentMask::EmptyMask)
-, entityVersions(DefaultCapacity, 0) {
+, entityVersions(DefaultCapacity, 0)
+, parentGraph(DefaultCapacity) {
     componentPools.reserve(ComponentMask::MaxComponentTypeCount);
     views.reserve(32);
     bl::event::Dispatcher::subscribe(this);
@@ -38,22 +39,41 @@ bool Registry::entityExists(Entity ent) const {
            entityVersions[index] == IdUtil::getEntityVersion(ent);
 }
 
-void Registry::destroyEntity(Entity ent) {
+void Registry::destroyEntity(Entity start) {
     std::lock_guard lock(entityLock);
-    const std::uint32_t index            = IdUtil::getEntityIndex(ent);
-    const ComponentMask::SimpleMask mask = entityMasks[index];
 
-    bl::event::Dispatcher::dispatch<event::EntityDestroyed>({ent});
-    for (auto& view : views) {
-        if (view->mask.passes(mask)) { view->removeEntity(ent); }
+    // determine list of entities to remove due to parenting
+    std::vector<Entity> toRemove;
+    std::vector<Entity> toVisit;
+    toRemove.reserve(16);
+    toVisit.reserve(16);
+    toVisit.emplace_back(start);
+
+    while (!toVisit.empty()) {
+        const Entity ent = toVisit.back();
+        toVisit.pop_back();
+
+        toRemove.emplace_back(ent);
+        for (Entity child : parentGraph.getChildren(ent)) { toVisit.emplace_back(child); }
     }
 
-    for (ComponentPoolBase* pool : componentPools) {
-        if (ComponentMask::has(mask, pool->ComponentIndex)) { pool->remove(ent); }
-    }
+    // remove all discovered entities
+    for (const Entity ent : toRemove) {
+        const std::uint32_t index            = IdUtil::getEntityIndex(ent);
+        const ComponentMask::SimpleMask mask = entityMasks[index];
 
-    entityAllocator.release(index);
-    entityMasks[index] = ComponentMask::EmptyMask;
+        bl::event::Dispatcher::dispatch<event::EntityDestroyed>({ent});
+        for (auto& view : views) {
+            if (view->mask.passes(mask)) { view->removeEntity(ent); }
+        }
+
+        for (ComponentPoolBase* pool : componentPools) {
+            if (ComponentMask::has(mask, pool->ComponentIndex)) { pool->remove(ent); }
+        }
+
+        entityAllocator.release(index);
+        entityMasks[index] = ComponentMask::EmptyMask;
+    }
 }
 
 void Registry::destroyAllEntities() {
@@ -74,8 +94,45 @@ void Registry::destroyAllEntities() {
     entityAllocator.releaseAll();
     std::fill(entityMasks.begin(), entityMasks.end(), ComponentMask::EmptyMask);
 
+    // reset relationships
+    parentGraph.reset();
+
     // clear views
     for (auto& view : views) { view->clearAndRefresh(); }
+}
+
+void Registry::setEntityParent(Entity child, Entity parent) {
+    std::lock_guard lock(entityLock);
+    const std::uint32_t ic = IdUtil::getEntityIndex(child);
+    const std::uint32_t ip = IdUtil::getEntityIndex(child);
+    if (!entityAllocator.isAllocated(ic) || !entityAllocator.isAllocated(ip)) {
+        BL_LOG_WARN << "Tried to parent bad entities: " << child << " <- " << parent;
+        return;
+    }
+
+    const ComponentMask mask{.required = entityMasks[ic]};
+    parentGraph.setParent(child, parent);
+    for (ComponentPoolBase* pool : componentPools) {
+        if (mask.contains(pool->ComponentIndex)) { pool->onParentSet(child, parent); }
+    }
+}
+
+void Registry::removeEntityParent(Entity child) {
+    std::lock_guard lock(entityLock);
+    const Entity parent = parentGraph.getParent(child);
+    if (parent == InvalidEntity) { return; }
+    const std::uint32_t ic = IdUtil::getEntityIndex(child);
+    const std::uint32_t ip = IdUtil::getEntityIndex(child);
+    if (!entityAllocator.isAllocated(ic) || !entityAllocator.isAllocated(ip)) {
+        BL_LOG_WARN << "Tried to un-parent bad entities: " << child << " <- " << parent;
+        return;
+    }
+
+    const ComponentMask mask{.required = entityMasks[ic]};
+    parentGraph.unParent(child);
+    for (ComponentPoolBase* pool : componentPools) {
+        if (mask.contains(pool->ComponentIndex)) { pool->onParentRemove(child); }
+    }
 }
 
 void Registry::observe(const event::ComponentPoolResized& resize) {

--- a/tests/Containers/CMakeLists.txt
+++ b/tests/Containers/CMakeLists.txt
@@ -1,11 +1,12 @@
 target_sources(BLIB.t PUBLIC
     Cache.t.cpp
-    FastQueue.t.cpp
-    RingBuffer.t.cpp
     FastEraseVector.t.cpp
-    ObjectPool.t.cpp
-    QuadTree.t.cpp
+    FastQueue.t.cpp
     Grid.t.cpp
+    IndexMappedList.t.cpp
+    ObjectPool.t.cpp
     ObjectWrapper.t.cpp
+    QuadTree.t.cpp
+    RingBuffer.t.cpp
     RingQueue.t.cpp
 )

--- a/tests/Containers/IndexMappedList.t.cpp
+++ b/tests/Containers/IndexMappedList.t.cpp
@@ -1,0 +1,124 @@
+#include <BLIB/Containers/IndexMappedList.hpp>
+#include <BLIB/Util/Random.hpp>
+#include <gtest/gtest.h>
+#include <string_view>
+
+namespace bl
+{
+namespace ctr
+{
+namespace unittest
+{
+TEST(IndexMappedList, SingleKeySingleValue) {
+    IndexMappedList<std::uint32_t, int> map;
+
+    EXPECT_FALSE(map.hasValues(5));
+    map.add(5, 10);
+    EXPECT_TRUE(map.hasValues(5));
+    EXPECT_TRUE(map.hasValue(5, 10));
+    for (int val : map.getValues(5)) { EXPECT_EQ(val, 10); }
+    map.remove(5);
+    EXPECT_FALSE(map.hasValues(5));
+    EXPECT_FALSE(map.hasValue(5, 10));
+
+    map.add(5, 10);
+    EXPECT_TRUE(map.hasValues(5));
+    EXPECT_TRUE(map.hasValue(5, 10));
+    for (int val : map.getValues(5)) { EXPECT_EQ(val, 10); }
+    map.removeValue(5, 10);
+    EXPECT_FALSE(map.hasValues(5));
+    EXPECT_FALSE(map.hasValue(5, 10));
+}
+
+TEST(IndexMappedList, SingleKeyMultiValue) {
+    IndexMappedList<std::uint32_t, int> map(1);
+
+    map.add(5, 5);
+    map.add(5, 55);
+    EXPECT_TRUE(map.hasValues(5));
+    EXPECT_TRUE(map.hasValue(5, 5));
+    EXPECT_TRUE(map.hasValue(5, 55));
+
+    map.add(5, 555);
+    EXPECT_TRUE(map.hasValue(5, 555));
+
+    map.removeValue(5, 55);
+    EXPECT_TRUE(map.hasValue(5, 5));
+    EXPECT_FALSE(map.hasValue(5, 55));
+    EXPECT_TRUE(map.hasValue(5, 555));
+
+    map.remove(5);
+    EXPECT_FALSE(map.hasValues(5));
+}
+
+TEST(IndexMappedList, RandomKeysAndValues) {
+    constexpr std::size_t KeyCount = std::numeric_limits<std::uint16_t>::max() / 2;
+    IndexMappedList<std::uint32_t, int> map;
+
+    // generate random key -> value set
+    std::vector<std::vector<int>> expected;
+    expected.resize(KeyCount);
+    for (auto& set : expected) {
+        const std::uint32_t count = util::Random::get<std::uint32_t>(0, 50);
+        set.reserve(count);
+        for (std::uint32_t i = 0; i < count; ++i) {
+            set.push_back(util::Random::get<int>(0, KeyCount));
+        }
+    }
+
+    // add all values to set
+    for (unsigned int key = 0; key < expected.size(); ++key) {
+        for (int val : expected[key]) { map.add(key, val); }
+    }
+
+    std::vector<bool> removed(KeyCount, false);
+    const auto verify = [&map, &expected, &removed](std::string_view ctx) {
+        for (unsigned int key = 0; key < expected.size(); ++key) {
+            if (expected[key].empty() || removed[key]) {
+                ASSERT_FALSE(map.hasValues(key)) << ctx << " | Contains unexpected key: " << key;
+            }
+            else {
+                ASSERT_TRUE(map.hasValues(key))
+                    << ctx << " | Does not contain expected key: " << key;
+                for (int val : expected[key]) {
+                    ASSERT_TRUE(map.hasValue(key, val))
+                        << ctx << " | key " << key << " Does not contain expected value: " << val;
+                }
+            }
+        }
+    };
+
+    // verify initial condition
+    verify("Initial Setup");
+
+    // randomly delete some values and verify
+    unsigned int rmCount = util::Random::get<unsigned int>(500, 5000);
+    for (unsigned int i = 0; i < rmCount; ++i) {
+        const std::uint32_t key = util::Random::get<std::uint32_t>(0, expected.size() - 1);
+        if (!expected[key].empty()) {
+            const unsigned int j = util::Random::get<unsigned int>(0, expected[key].size() - 1);
+            map.removeValue(key, expected[key][j]);
+            expected[key].erase(expected[key].begin() + j);
+        }
+    }
+    verify("Random Value Deletion");
+
+    // randomly delete some keys and verify
+    rmCount = util::Random::get<unsigned int>(500, 5000);
+    std::vector<unsigned int> toRm;
+    for (unsigned int i = 0; i < rmCount; ++i) {
+        const std::uint32_t key = util::Random::get<std::uint32_t>(0, expected.size() - 1);
+        map.remove(key);
+        removed[key] = true;
+    }
+    verify("Random Key Deletion");
+
+    // clear and test all keys gone
+    std::fill(removed.begin(), removed.end(), true);
+    map.clear();
+    verify("Clear");
+}
+
+} // namespace unittest
+} // namespace ctr
+} // namespace bl

--- a/tests/ECS/CMakeLists.txt
+++ b/tests/ECS/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(BLIB.t PUBLIC
     Cleaner.t.cpp
+    ParentGraph.t.cpp
     Registry.t.cpp
 )

--- a/tests/ECS/CMakeLists.txt
+++ b/tests/ECS/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_sources(BLIB.t PUBLIC
     Cleaner.t.cpp
+    DependencyGraph.t.cpp
     ParentGraph.t.cpp
     Registry.t.cpp
 )

--- a/tests/ECS/Cleaner.t.cpp
+++ b/tests/ECS/Cleaner.t.cpp
@@ -7,7 +7,7 @@ namespace ecs
 {
 namespace unittest
 {
-TEST(EntityCleaner, Disarmed) {
+TEST(ECSEntityCleaner, Disarmed) {
     Registry testRegistry;
 
     Entity e = InvalidEntity;
@@ -20,7 +20,7 @@ TEST(EntityCleaner, Disarmed) {
     EXPECT_TRUE(testRegistry.entityExists(e));
 }
 
-TEST(EntityCleaner, Armed) {
+TEST(ECSEntityCleaner, Armed) {
     Registry testRegistry;
 
     Entity e = InvalidEntity;

--- a/tests/ECS/DependencyGraph.t.cpp
+++ b/tests/ECS/DependencyGraph.t.cpp
@@ -22,7 +22,7 @@ TEST(ECSDependencyGraph, BasicDependencies) {
     graph.removeDependency(resource, user1);
     EXPECT_TRUE(graph.hasDependencies(resource));
 
-    graph.removeEntity(user2);
+    graph.removeDependency(resource, user2);
     EXPECT_FALSE(graph.hasDependencies(resource));
 }
 

--- a/tests/ECS/DependencyGraph.t.cpp
+++ b/tests/ECS/DependencyGraph.t.cpp
@@ -1,0 +1,31 @@
+#include <BLIB/ECS/DependencyGraph.hpp>
+#include <gtest/gtest.h>
+
+namespace bl
+{
+namespace ecs
+{
+namespace unittest
+{
+TEST(ECSDependencyGraph, BasicDependencies) {
+    const Entity resource = IdUtil::composeEntity(0, 1);
+    const Entity user1    = IdUtil::composeEntity(1, 1);
+    const Entity user2    = IdUtil::composeEntity(1, 1);
+
+    DependencyGraph graph(10);
+    EXPECT_FALSE(graph.hasDependencies(resource));
+    graph.addDependency(resource, user1);
+    EXPECT_TRUE(graph.hasDependencies(resource));
+    graph.addDependency(resource, user2);
+    EXPECT_TRUE(graph.hasDependencies(resource));
+
+    graph.removeDependency(resource, user1);
+    EXPECT_TRUE(graph.hasDependencies(resource));
+
+    graph.removeEntity(user2);
+    EXPECT_FALSE(graph.hasDependencies(resource));
+}
+
+} // namespace unittest
+} // namespace ecs
+} // namespace bl

--- a/tests/ECS/ParentGraph.t.cpp
+++ b/tests/ECS/ParentGraph.t.cpp
@@ -1,0 +1,31 @@
+#include <BLIB/ECS/ParentGraph.hpp>
+#include <gtest/gtest.h>
+
+namespace bl
+{
+namespace ecs
+{
+namespace unittest
+{
+TEST(ECSParentGraph, BasicParenting) {
+    const Entity child  = IdUtil::composeEntity(0, 1);
+    const Entity parent = IdUtil::composeEntity(1, 1);
+
+    ParentGraph graph(0);
+
+    EXPECT_EQ(graph.getParent(child), InvalidEntity);
+    EXPECT_EQ(graph.getChildren(parent).begin(), graph.getChildren(parent).end());
+
+    graph.setParent(child, parent);
+    EXPECT_EQ(graph.getParent(child), parent);
+    EXPECT_NE(graph.getChildren(parent).begin(), graph.getChildren(parent).end());
+    EXPECT_EQ(*graph.getChildren(parent).begin(), child);
+
+    graph.unParent(child);
+    EXPECT_EQ(graph.getParent(child), InvalidEntity);
+    EXPECT_EQ(graph.getChildren(parent).begin(), graph.getChildren(parent).end());
+}
+
+} // namespace unittest
+} // namespace ecs
+} // namespace bl

--- a/tests/ECS/Registry.t.cpp
+++ b/tests/ECS/Registry.t.cpp
@@ -22,6 +22,14 @@ struct DestroyTestComponent {
 
     bool& destroyed;
 };
+
+struct ParentTestComponent : public trait::ParentAware<ParentTestComponent> {
+    int payload;
+
+    ParentTestComponent(int p)
+    : payload(p) {}
+};
+
 } // namespace
 
 TEST(ECS, EntityCreateAndDestroy) {
@@ -313,6 +321,72 @@ TEST(ECS, ClearRegistry) {
         EXPECT_FALSE(testRegistry.entityExists(ent));
         EXPECT_EQ(testRegistry.getComponent<int>(ent), nullptr);
     }
+}
+
+TEST(ECS, ParentBeforeCreate) {
+    Registry testRegistry;
+
+    Entity child  = testRegistry.createEntity();
+    Entity parent = testRegistry.createEntity();
+    testRegistry.setEntityParent(child, parent);
+
+    auto* childCom  = testRegistry.addComponent<ParentTestComponent>(child, 10);
+    auto* parentCom = testRegistry.addComponent<ParentTestComponent>(parent, 100);
+
+    EXPECT_TRUE(childCom->hasParent());
+    EXPECT_FALSE(parentCom->hasParent());
+    EXPECT_EQ(childCom->payload, 10);
+    EXPECT_EQ(parentCom->payload, 100);
+    EXPECT_EQ(childCom->getParent().payload, 100);
+
+    testRegistry.destroyEntity(parent);
+    EXPECT_FALSE(testRegistry.entityExists(parent));
+    EXPECT_FALSE(testRegistry.entityExists(child));
+}
+
+TEST(ECS, ParentAfterCreate) {
+    Registry testRegistry;
+
+    Entity child  = testRegistry.createEntity();
+    Entity parent = testRegistry.createEntity();
+
+    auto* childCom  = testRegistry.addComponent<ParentTestComponent>(child, 10);
+    auto* parentCom = testRegistry.addComponent<ParentTestComponent>(parent, 100);
+    testRegistry.setEntityParent(child, parent);
+
+    EXPECT_TRUE(childCom->hasParent());
+    EXPECT_FALSE(parentCom->hasParent());
+    EXPECT_EQ(childCom->payload, 10);
+    EXPECT_EQ(parentCom->payload, 100);
+    EXPECT_EQ(childCom->getParent().payload, 100);
+
+    testRegistry.destroyEntity(parent);
+    EXPECT_FALSE(testRegistry.entityExists(parent));
+    EXPECT_FALSE(testRegistry.entityExists(child));
+}
+
+TEST(ECS, ParentRemove) {
+    Registry testRegistry;
+
+    Entity child  = testRegistry.createEntity();
+    Entity parent = testRegistry.createEntity();
+
+    auto* childCom  = testRegistry.addComponent<ParentTestComponent>(child, 10);
+    auto* parentCom = testRegistry.addComponent<ParentTestComponent>(parent, 100);
+    testRegistry.setEntityParent(child, parent);
+
+    EXPECT_TRUE(childCom->hasParent());
+    EXPECT_FALSE(parentCom->hasParent());
+    EXPECT_EQ(childCom->payload, 10);
+    EXPECT_EQ(parentCom->payload, 100);
+    EXPECT_EQ(childCom->getParent().payload, 100);
+
+    testRegistry.removeEntityParent(child);
+    EXPECT_FALSE(childCom->hasParent());
+
+    testRegistry.destroyEntity(parent);
+    EXPECT_FALSE(testRegistry.entityExists(parent));
+    EXPECT_TRUE(testRegistry.entityExists(child));
 }
 
 } // namespace unittest

--- a/tests/ECS/Registry.t.cpp
+++ b/tests/ECS/Registry.t.cpp
@@ -389,6 +389,42 @@ TEST(ECS, ParentRemove) {
     EXPECT_TRUE(testRegistry.entityExists(child));
 }
 
+TEST(ECS, Dependencies) {
+    Registry testRegistry;
+
+    Entity child  = testRegistry.createEntity();
+    Entity parent = testRegistry.createEntity();
+
+    // test marked removal
+    testRegistry.addDependency(parent, child);
+    EXPECT_TRUE(testRegistry.isDependedOn(parent));
+    EXPECT_FALSE(testRegistry.destroyEntity(parent));
+    EXPECT_TRUE(testRegistry.destroyEntity(child));
+    EXPECT_FALSE(testRegistry.entityExists(parent));
+
+    // test add and remove dep
+    child  = testRegistry.createEntity();
+    parent = testRegistry.createEntity();
+    testRegistry.addDependency(parent, child);
+    testRegistry.removeDependency(parent, child);
+    EXPECT_TRUE(testRegistry.destroyEntity(parent));
+    EXPECT_TRUE(testRegistry.destroyEntity(child));
+
+    // test remove in order
+    child  = testRegistry.createEntity();
+    parent = testRegistry.createEntity();
+    testRegistry.addDependency(parent, child);
+    EXPECT_TRUE(testRegistry.destroyEntity(child));
+    EXPECT_TRUE(testRegistry.destroyEntity(parent));
+
+    // test delete on remove
+    child  = testRegistry.createEntity();
+    parent = testRegistry.createEntity();
+    testRegistry.addDependency(parent, child);
+    testRegistry.removeDependencyAndDestroyIfPossible(parent, child);
+    EXPECT_FALSE(testRegistry.entityExists(parent));
+}
+
 } // namespace unittest
 } // namespace ecs
 } // namespace bl


### PR DESCRIPTION
Resolves #173 

Adds the following relationship types in ECS:
- Parenting:
    - Children are removed when parent is removed
    - Includes `ParentAware` component helper base class
- Dependencies:
    - Defers entity destruction until all users are destroyed

Introduces the `IndexMappedList` container which uses 0-based indices as keys into a linked list of payloads that are stored in one contiguous region in memory.