### PR TITLE
Clean up threadpool and increase test timeout

### DIFF
--- a/examples/Graphics/.gitignore
+++ b/examples/Graphics/.gitignore
@@ -1,1 +1,1 @@
-animation
+graphics

--- a/src/Util/ThreadPool.cpp
+++ b/src/Util/ThreadPool.cpp
@@ -61,7 +61,7 @@ void ThreadPool::shutdown() {
 }
 
 std::future<void> ThreadPool::queueTask(Task&& task) {
-    if (shuttingDown.load() || !running()) { return {}; }
+    if (!running()) { return {}; }
 
     std::unique_lock lock(taskMutex);
     if (shuttingDown.load()) { return {}; } // in case of race
@@ -94,8 +94,6 @@ void ThreadPool::worker() {
         lock.lock();
         --inFlightCount;
         taskDoneCv.notify_all();
-
-        if (shuttingDown) { break; }
     }
 
     BL_LOG_INFO << "Worker thread terminated";

--- a/tests/Util/ThreadPool.t.cpp
+++ b/tests/Util/ThreadPool.t.cpp
@@ -63,7 +63,7 @@ TEST(ThreadPool, ShutdownLongRunningTask) {
     };
 
     auto future       = std::async(test);
-    const auto result = future.wait_for(std::chrono::milliseconds(750));
+    const auto result = future.wait_for(std::chrono::milliseconds(1000));
     EXPECT_NE(result, std::future_status::timeout);
     if (result == std::future_status::timeout) { std::terminate(); }
 }


### PR DESCRIPTION
Looking at logs the thread pool never deadlocks, it closes as expected but the test still times out. Cleaned up some redundant statements and increased the test timeout. Could not get it to fail locally after running several hundred times.

Resolves #190 